### PR TITLE
Fix some data flow issues

### DIFF
--- a/allora_forge_builder_kit/workflow.py
+++ b/allora_forge_builder_kit/workflow.py
@@ -212,8 +212,12 @@ class AlloraMLWorkflow:
             combined_df = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
             if not combined_df.empty:
                 latest_ts = sorted(pd.to_datetime(combined_df["date"]).dt.date.unique())[-2]
-                live_df = self.fetch_ohlcv_data(t, latest_ts.strftime("%Y-%m-%d"))
-                combined_df = pd.concat([combined_df, live_df], ignore_index=True)
+                try:
+                    live_df = self.fetch_ohlcv_data(t, latest_ts.strftime("%Y-%m-%d"))
+                    combined_df = pd.concat([combined_df, live_df], ignore_index=True)
+                except ValueError:
+                    # No data returned from API, skip adding live_df
+                    pass
                 combined_df["date"] = pd.to_datetime(combined_df["date"])
                 combined_df = combined_df.drop_duplicates(subset="date")
             else:
@@ -279,8 +283,12 @@ class AlloraMLWorkflow:
             combined_df = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
             if not combined_df.empty:
                 latest_ts = sorted(pd.to_datetime(combined_df["date"]).dt.date.unique())[-2]
-                live_df = self.fetch_ohlcv_data(t, latest_ts.strftime("%Y-%m-%d"))
-                combined_df = pd.concat([combined_df, live_df], ignore_index=True)
+                try:
+                    live_df = self.fetch_ohlcv_data(t, latest_ts.strftime("%Y-%m-%d"))
+                    combined_df = pd.concat([combined_df, live_df], ignore_index=True)
+                except ValueError:
+                    # No data returned from API, skip adding live_df
+                    pass
                 combined_df['date'] = pd.to_datetime(combined_df['date'])
                 combined_df = combined_df.drop_duplicates(subset='date')
             else:


### PR DESCRIPTION
Handle cases when either historical CSV files are not available or live data is not available, to not crash and still return the data that is available. This just lets data come through when it is only partially available in our api.