### PR TITLE
fix(deploy): use allora-sdk run parameter for AlloraWorker

### DIFF
--- a/notebooks/deploy_worker.py
+++ b/notebooks/deploy_worker.py
@@ -36,8 +36,8 @@ async def main():
     print(f"\nStarting Allora worker for Topic {TOPIC_ID}...")
 
     worker = AlloraWorker(
+        run=predict_fn,
         topic_id=TOPIC_ID,
-        predict_fn=predict_fn,
         api_key=api_key,
         debug=DEBUG_MODE,
     )


### PR DESCRIPTION
fixing deploy script in example

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update deploy_worker.py to use the AlloraWorker run parameter instead of predict_fn. This aligns with the latest allora-sdk API and prevents startup errors in the example deploy script.

<sup>Written for commit db3587679a4f3c32c32c55e666871e2c1315b251. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

