### PR TITLE
fix: use text search for Atlas dataset resolution

### DIFF
--- a/allora_forge_builder_kit/atlas_data_manager.py
+++ b/allora_forge_builder_kit/atlas_data_manager.py
@@ -100,25 +100,38 @@ class AtlasDataManager(BaseDataManager):
             return self._dataset_cache[norm]
 
         expected_name = f"tiingo_{norm}_1min"
-        resp = requests.get(
-            f"{self.base_url}/datasets/",
-            headers=self.headers,
-            params={"search": expected_name, "limit": 10},
-            timeout=30,
-        )
-        resp.raise_for_status()
-        results = resp.json().get("results", [])
+        try:
+            resp = requests.get(
+                f"{self.base_url}/datasets/",
+                headers=self.headers,
+                params={"search": expected_name, "limit": 10},
+                timeout=30,
+            )
+            resp.raise_for_status()
+            results = resp.json().get("results", [])
+        except requests.exceptions.RequestException as e:
+            raise RuntimeError(
+                f"Atlas API error while resolving dataset for ticker '{ticker}': {e}"
+            ) from e
 
         match = next((ds for ds in results if ds.get("name") == expected_name), None)
-        if match is not None:
-            self._dataset_cache[norm] = match["id"]
-            return match["id"]
+        if match is None:
+            raise ValueError(
+                f"No Atlas dataset with expected name '{expected_name}' found for "
+                f"ticker '{ticker}'. Got {len(results)} result(s)"
+                + (f"; first was '{results[0].get('name')}'" if results else "")
+                + ". Use list_available_datasets() or search_datasets() to discover datasets."
+            )
 
-        raise ValueError(
-            f"No Atlas dataset with expected name '{expected_name}' found for "
-            f"ticker '{ticker}'. Got {len(results)} result(s)"
-            + (f"; first was '{results[0].get('name')}'" if results else "")
-        )
+        dataset_id = match.get("id")
+        if not isinstance(dataset_id, int):
+            raise TypeError(
+                f"Atlas returned non-integer dataset ID {dataset_id!r} "
+                f"for '{expected_name}'"
+            )
+
+        self._dataset_cache[norm] = dataset_id
+        return dataset_id
 
     # ------------------------------------------------------------------
     # Data fetching
@@ -659,16 +672,24 @@ class AtlasDataManager(BaseDataManager):
         source: str = "tiingo",
         frequency: str = "1min",
     ) -> List[Dict]:
-        """List datasets available on Atlas for a given source and frequency."""
-        params = {"source": source, "frequency": frequency, "limit": 250}
+        """List datasets available on Atlas for a given source and frequency.
+
+        Uses text search on ``/datasets/`` and filters results client-side,
+        since ``/datasets/search/`` currently rejects multiple metadata filters.
+        """
         resp = requests.get(
-            f"{self.base_url}/datasets/search/",
+            f"{self.base_url}/datasets/",
             headers=self.headers,
-            params=params,
+            params={"search": source, "limit": 250},
             timeout=30,
         )
         resp.raise_for_status()
-        return resp.json().get("results", [])
+        results = resp.json().get("results", [])
+        return [
+            ds for ds in results
+            if ds.get("metadata", {}).get("source") == source
+            and ds.get("metadata", {}).get("frequency") == frequency
+        ]
 
     def search_datasets(self, query: str) -> List[Dict]:
         """Free-text search across Atlas dataset names and descriptions."""

--- a/allora_forge_builder_kit/atlas_data_manager.py
+++ b/allora_forge_builder_kit/atlas_data_manager.py
@@ -99,28 +99,25 @@ class AtlasDataManager(BaseDataManager):
         if norm in self._dataset_cache:
             return self._dataset_cache[norm]
 
-        dataset_name = f"tiingo_{norm}_1min"
+        expected_name = f"tiingo_{norm}_1min"
         resp = requests.get(
-            f"{self.base_url}/datasets/search/",
+            f"{self.base_url}/datasets/",
             headers=self.headers,
-            params={"source": "tiingo", "ticker": norm, "frequency": "1min"},
+            params={"search": expected_name, "limit": 10},
             timeout=30,
         )
         resp.raise_for_status()
         results = resp.json().get("results", [])
 
-        for ds in results:
-            if ds["name"] == dataset_name:
-                self._dataset_cache[norm] = ds["id"]
-                return ds["id"]
-
-        if results:
-            self._dataset_cache[norm] = results[0]["id"]
-            return results[0]["id"]
+        match = next((ds for ds in results if ds.get("name") == expected_name), None)
+        if match is not None:
+            self._dataset_cache[norm] = match["id"]
+            return match["id"]
 
         raise ValueError(
-            f"No Atlas dataset found for ticker '{ticker}' "
-            f"(searched for '{dataset_name}')"
+            f"No Atlas dataset with expected name '{expected_name}' found for "
+            f"ticker '{ticker}'. Got {len(results)} result(s)"
+            + (f"; first was '{results[0].get('name')}'" if results else "")
         )
 
     # ------------------------------------------------------------------

--- a/tests/test_data_managers.py
+++ b/tests/test_data_managers.py
@@ -192,6 +192,93 @@ def test_atlas_manager_default_directory():
     assert dm.base_dir == "parquet_data_allora"
 
 
+import requests as _requests
+from unittest.mock import patch, MagicMock
+
+
+class TestResolveDatasetId:
+    """Unit tests for AtlasDataManager._resolve_dataset_id."""
+
+    def _make_dm(self, tmp_path):
+        return AtlasDataManager(
+            api_key="test-key", interval="5m",
+            base_dir=str(tmp_path / "atlas_resolve"),
+        )
+
+    def _mock_response(self, results, status_code=200):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {"results": results}
+        return resp
+
+    def test_happy_path_exact_name_match(self, tmp_path):
+        dm = self._make_dm(tmp_path)
+        results = [
+            {"id": 99, "name": "candlegpt_15min_btcusd"},
+            {"id": 3, "name": "tiingo_btcusd_1min"},
+        ]
+        with patch("requests.get", return_value=self._mock_response(results)) as mock_get:
+            ds_id = dm._resolve_dataset_id("btcusd")
+
+        assert ds_id == 3
+        assert dm._dataset_cache["btcusd"] == 3
+        call_params = mock_get.call_args[1]["params"]
+        assert call_params["search"] == "tiingo_btcusd_1min"
+        assert call_params["limit"] == 10
+
+    def test_cache_hit_skips_http(self, tmp_path):
+        dm = self._make_dm(tmp_path)
+        dm._dataset_cache["btcusd"] = 42
+        with patch("requests.get") as mock_get:
+            ds_id = dm._resolve_dataset_id("btcusd")
+        assert ds_id == 42
+        mock_get.assert_not_called()
+
+    def test_no_results_raises_valueerror(self, tmp_path):
+        dm = self._make_dm(tmp_path)
+        with patch("requests.get", return_value=self._mock_response([])):
+            with pytest.raises(ValueError, match="No Atlas dataset"):
+                dm._resolve_dataset_id("btcusd")
+
+    def test_ambiguous_results_selects_correct_name(self, tmp_path):
+        dm = self._make_dm(tmp_path)
+        results = [
+            {"id": 50, "name": "kraken_btcusd_1min"},
+            {"id": 3, "name": "tiingo_btcusd_1min"},
+        ]
+        with patch("requests.get", return_value=self._mock_response(results)):
+            ds_id = dm._resolve_dataset_id("btcusd")
+        assert ds_id == 3
+
+    def test_no_exact_match_raises_even_with_results(self, tmp_path):
+        dm = self._make_dm(tmp_path)
+        results = [{"id": 50, "name": "kraken_btcusd_1min"}]
+        with patch("requests.get", return_value=self._mock_response(results)):
+            with pytest.raises(ValueError, match="kraken_btcusd_1min"):
+                dm._resolve_dataset_id("btcusd")
+
+    def test_http_error_raises_runtime_error(self, tmp_path):
+        dm = self._make_dm(tmp_path)
+        with patch("requests.get", side_effect=_requests.exceptions.ConnectionError("network")):
+            with pytest.raises(RuntimeError, match="Atlas API error"):
+                dm._resolve_dataset_id("btcusd")
+
+    def test_non_integer_id_raises_type_error(self, tmp_path):
+        dm = self._make_dm(tmp_path)
+        results = [{"id": None, "name": "tiingo_btcusd_1min"}]
+        with patch("requests.get", return_value=self._mock_response(results)):
+            with pytest.raises(TypeError, match="non-integer"):
+                dm._resolve_dataset_id("btcusd")
+
+    def test_ticker_normalization(self, tmp_path):
+        dm = self._make_dm(tmp_path)
+        results = [{"id": 3, "name": "tiingo_btcusd_1min"}]
+        with patch("requests.get", return_value=self._mock_response(results)):
+            assert dm._resolve_dataset_id("BTC/USD") == 3
+            assert dm._resolve_dataset_id("BTC-USD") == 3
+
+
 def test_atlas_bulk_download_chunked_splits_on_failure(tmp_path):
     dm = AtlasDataManager(api_key="test-key", interval="5m", base_dir=str(tmp_path / "allora_data"))
 


### PR DESCRIPTION
## Summary
- The `/api/datasets/search/` metadata endpoint currently rejects requests with multiple filter parameters, breaking `_resolve_dataset_id` and all backfills.
- Switches to `/api/datasets/?search={ticker}_1min` which avoids the multi-filter limitation.

## Test plan
- [x] Backfill completes successfully against live Atlas API
- [x] Dataset resolves correctly for `btcusd`
- [x] Full workflow produces expected feature/target dataframe

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use Atlas text search for dataset resolution with exact name matching and stronger validation. Bypasses the broken `/datasets/search/` filters and restores backfills.

- **Bug Fixes**
  - Switched to `/api/datasets/?search=tiingo_{ticker}_1min&limit=10` and removed the “first result” fallback.
  - Added robust error handling (try/except around HTTP; raise `RuntimeError` on network failures) and validated dataset ID is an int.
  - Improved error messages with result count, first result name, and pointers to `list_available_datasets()`/`search_datasets()`.
  - Updated `list_available_datasets()` to use `/datasets/?search=` with client-side filtering by `source` and `frequency`.
  - Added 8 unit tests for `_resolve_dataset_id` covering happy path, cache hits, ambiguous results, no match, HTTP errors, ID type checks, and ticker normalization.

<sup>Written for commit df1062a7e8984884405e6ee16e441b0836211087. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

