### PR TITLE
Add allora_research_model_skills bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Build, evaluate, and deploy ML inference workers on the [Allora Network](https:/
 - [Python API (quick reference)](#python-api-quick-reference)
 - [The learning problem](#the-learning-problem)
 - [Evaluation metrics](#evaluation-metrics)
+- [Model creation skills](#model-creation-skills)
 - [File map](#file-map)
 - [Testing](#testing)
 - [Links](#links)
@@ -303,6 +304,20 @@ All three produce a complete, runnable pipeline (data loader, feature engineerin
 | 3 | C |
 | 2 | D |
 | ≤ 1 | F |
+
+---
+
+## Model creation skills
+
+The [`allora_research_model_skills/`](allora_research_model_skills/README.md) bundle contains three Claude Code skills for building financial prediction models. Each enters model design from a different angle:
+
+| Skill | Entry point |
+|-------|-------------|
+| `forge-hypothesis-driven` | Start from a theory about what moves markets (deductive) |
+| `forge-signal-discovery` | Start from interesting data, discover what is predictable (inductive) |
+| `forge-robustness-first` | Start from validation gates, work backwards to a design that survives them (adversarial) |
+
+All three produce a complete, runnable pipeline and satisfy the same nine methodology principles. See [`allora_research_model_skills/README.md`](allora_research_model_skills/README.md) for selection guidance.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -269,13 +269,7 @@ From here, improving your score comes down to three levers:
 2. **Model and regularization** — early stopping, tree depth, learning rate, and subsampling to keep variance in check.
 3. **Maximizing out-of-sample metrics** — the evaluation suite (DA, Pearson $r$, WRMSE, CZAR) is the scorecard, not in-sample loss. A higher grade means better generalization and a higher expected score on the Allora network.
 
-For methodology guidance on each of these levers, the [`allora_research_model_skills/`](allora_research_model_skills/README.md) bundle contains three Claude Code skills, each entering model design from a different angle:
-
-- **`forge-hypothesis-driven`** — start from a theory about what moves markets, then build features to test it (deductive).
-- **`forge-signal-discovery`** — start from interesting data, then discover what is predictable in it (inductive).
-- **`forge-robustness-first`** — start from validation gates, then work backwards to a design that survives them (adversarial).
-
-All three produce a complete, runnable pipeline (data loader, feature engineering, model, validation, monitoring) and satisfy the same nine methodology principles. See the bundle's README for selection guidance.
+For structured methodology guidance on each of these levers, see the [Model creation skills](#model-creation-skills) section.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ From here, improving your score comes down to three levers:
 2. **Model and regularization** — early stopping, tree depth, learning rate, and subsampling to keep variance in check.
 3. **Maximizing out-of-sample metrics** — the evaluation suite (DA, Pearson $r$, WRMSE, CZAR) is the scorecard, not in-sample loss. A higher grade means better generalization and a higher expected score on the Allora network.
 
+For methodology on each of these levers, see [`allora_research_model_skills/`](allora_research_model_skills/README.md) — three Claude Code skills covering hypothesis-driven, signal-discovery, and robustness-first approaches to model design.
+
 ---
 
 ## Evaluation metrics
@@ -313,6 +315,7 @@ From here, improving your score comes down to three levers:
 | `allora_forge_builder_kit/worker_manager.py` | Wallet creation, key management, process lifecycle |
 | `allora_forge_builder_kit/worker_monitor.py` | On-chain event tracking |
 | `allora_forge_builder_kit/web_dashboard.py` | Web monitoring UI |
+| `allora_research_model_skills/` | Methodology skills for building generalizable financial models (hypothesis-driven, signal-discovery, robustness-first) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,13 @@ From here, improving your score comes down to three levers:
 2. **Model and regularization** — early stopping, tree depth, learning rate, and subsampling to keep variance in check.
 3. **Maximizing out-of-sample metrics** — the evaluation suite (DA, Pearson $r$, WRMSE, CZAR) is the scorecard, not in-sample loss. A higher grade means better generalization and a higher expected score on the Allora network.
 
-For methodology on each of these levers, see [`allora_research_model_skills/`](allora_research_model_skills/README.md) — three Claude Code skills covering hypothesis-driven, signal-discovery, and robustness-first approaches to model design.
+For methodology guidance on each of these levers, the [`allora_research_model_skills/`](allora_research_model_skills/README.md) bundle contains three Claude Code skills, each entering model design from a different angle:
+
+- **`forge-hypothesis-driven`** — start from a theory about what moves markets, then build features to test it (deductive).
+- **`forge-signal-discovery`** — start from interesting data, then discover what is predictable in it (inductive).
+- **`forge-robustness-first`** — start from validation gates, then work backwards to a design that survives them (adversarial).
+
+All three produce a complete, runnable pipeline (data loader, feature engineering, model, validation, monitoring) and satisfy the same nine methodology principles. See the bundle's README for selection guidance.
 
 ---
 

--- a/allora_research_model_skills/README.md
+++ b/allora_research_model_skills/README.md
@@ -48,7 +48,7 @@ These skills solve both problems:
 
 ## Prerequisites
 
-- **Python 3.9+**
+- **Python 3.10+** (matches the builder kit's `pyproject.toml`)
 - **ML libraries:** scikit-learn, XGBoost or LightGBM (or your preferred gradient boosting / modeling library)
 - **Data access:** Market data via a public API (exchange APIs, data aggregators) or your own data sources
 - **Development environment:** Claude Code or Codex with skill support

--- a/allora_research_model_skills/README.md
+++ b/allora_research_model_skills/README.md
@@ -1,0 +1,101 @@
+# Allora Forge Model Creation Skills
+
+## What These Are
+
+These are Claude Code skills that guide you through building a financial prediction model from scratch. Each skill encodes a battle-tested development methodology — not a specific model or feature set, but the **design philosophy** behind models that actually generalize to live markets.
+
+You will produce a complete, runnable prediction pipeline: data loading, feature engineering, model training, validation, and deployment monitoring. Working code, not documentation.
+
+## Why They Exist
+
+Allora's decentralized intelligence network gets stronger when participants submit models that are both **performant** and **diverse**. A network of clones — even good clones — is weaker than a network of diverse models that approach prediction from different angles.
+
+These skills solve both problems:
+- **Performance floor:** They encode the methodology behind models that survive out-of-sample validation, so you avoid the common pitfalls (lookahead contamination, overfitting, optimizer gaming) that kill live performance.
+- **Diversity by design:** Three different skills guide you down fundamentally different reasoning paths. Your model's architecture, features, and loss function will reflect your unique starting point — not a template copied from someone else.
+
+## The Three Skills
+
+### Hypothesis-Driven (`forge-hypothesis-driven`)
+
+*"I have a theory about what moves markets."*
+
+**For:** Builders with a clear prediction target and a theory about what drives it. You believe specific signals (momentum, volatility regimes, microstructure, cross-asset relationships) predict your target, and you want a structured way to test that belief.
+
+**Approach:** Deductive. You start with your hypothesis, translate it into testable features organized around estimation goals, and build a pipeline designed to falsify or confirm your theory.
+
+**Best when:** You have domain knowledge you want to encode. You can articulate why your features should predict the target before seeing any results.
+
+### Signal Discovery (`forge-signal-discovery`)
+
+*"I have interesting data and want to find what's predictable."*
+
+**For:** Builders with access to interesting data sources (alternative data, on-chain metrics, order flow, social signals) who want to discover what, if anything, is predictable in that data.
+
+**Approach:** Inductive. You start with your data, rigorously assess what information it contains, and build prediction targets and features grounded in what the data can actually support.
+
+**Best when:** Your edge is the data itself, not a pre-existing theory. You want to explore systematically rather than guess.
+
+### Robustness-First (`forge-robustness-first`)
+
+*"I want maximum confidence my model generalizes."*
+
+**For:** Builders who have been burned by overfitting, or who simply want the highest confidence that their model is real before deploying capital.
+
+**Approach:** Adversarial. You start by defining your validation framework and quality gates, then work backwards — designing features, architecture, and loss function specifically to survive the tests you already set up.
+
+**Best when:** You prioritize generalization over raw backtest performance. You are willing to build a simpler model if it means higher confidence that it works in production.
+
+## Prerequisites
+
+- **Python 3.9+**
+- **ML libraries:** scikit-learn, XGBoost or LightGBM (or your preferred gradient boosting / modeling library)
+- **Data access:** Market data via a public API (exchange APIs, data aggregators) or your own data sources
+- **Development environment:** Claude Code or Codex with skill support
+
+No specific frameworks or proprietary dependencies required. The skills are agnostic to your data source and modeling library.
+
+## How to Invoke
+
+These are Claude Code skills. Invoke them by name:
+
+```
+forge-hypothesis-driven
+forge-signal-discovery
+forge-robustness-first
+```
+
+The skill will guide you through an interactive workflow — asking questions, prompting decisions, and producing code artifacts at each stage. You drive the choices; the skill ensures the methodology is sound.
+
+## What Gets Produced
+
+Each skill produces a complete set of pipeline artifacts:
+
+| Artifact | Description |
+|----------|-------------|
+| `config.yaml` | Full pipeline configuration: target, horizon, data source, features, model, loss, validation gates |
+| `data_loader.py` | Data fetching, caching, and quality validation |
+| `feature_engineer.py` | Feature computation with horizon-adaptive parameters and lookahead prevention |
+| `model.py` | Model definition, loss function, and training loop |
+| `validation.py` | Quality gates as executable pass/fail checks |
+| `evaluate.py` | Pipeline orchestrator running three-stage validation |
+| `evaluation_report.md` | Full results: per-stage performance, gate outcomes, diagnostics |
+| `monitor.py` | Post-deployment monitoring for performance, feature drift, and staleness |
+
+Everything is config-driven and reproducible. Someone else should be able to re-run your pipeline from the config and get the same results.
+
+## Shared Methodology
+
+All three skills build on the same nine principles, documented in `shared/methodology.md`. The principles cover:
+
+1. Physics-first feature engineering
+2. Horizon-adaptive parameterization
+3. Lookahead prevention by architecture
+4. Three-stage separation (optimize, evaluate, deploy)
+5. Loss function as a modeling decision
+6. Multi-threshold signal validation
+7. Optimizer-gaming prevention
+8. Configuration-driven experimentation
+9. Problem decomposition
+
+The skills differ in entry point, ordering, and emphasis — not in rigor. Every pipeline produced by any skill satisfies all nine principles.

--- a/allora_research_model_skills/hypothesis-driven/SKILL.md
+++ b/allora_research_model_skills/hypothesis-driven/SKILL.md
@@ -1,0 +1,381 @@
+---
+name: forge-hypothesis-driven
+description: >
+  Guide creation of a prediction model for Allora using hypothesis-driven development methodology.
+  Produces a complete pipeline: data loading, feature engineering, model training, and validation.
+disable-model-invocation: true
+---
+
+# Hypothesis-Driven Model Development
+
+You are guiding a builder through creating a financial prediction model for the Allora network. Your approach is **hypothesis-driven**: the builder starts with a prediction target and a theory about what drives it, and every subsequent decision flows from that theory.
+
+This skill produces a **complete, runnable pipeline** — not a plan, not pseudocode, but working code that loads data, engineers features, trains a model, validates it, and reports results.
+
+## Methodology
+
+This workflow implements the nine principles described in [the methodology](../shared/methodology.md). Read it for the full rationale. In brief:
+
+1. **Physics-first feature engineering** — features organized around estimation goals
+2. **Horizon-adaptive parameterization** — all periods derived from prediction horizon
+3. **Lookahead prevention by architecture** — structural guardrails, not developer discipline
+4. **Three-stage separation** — optimize, evaluate, deploy (no double-dipping)
+5. **Loss function as a modeling decision** — encodes beliefs, not an afterthought
+6. **Multi-threshold signal validation** — simultaneous independent quality gates
+7. **Optimizer-gaming prevention** — val=test parity, constant test coverage
+8. **Configuration-driven experimentation** — specs are data, not code
+9. **Problem decomposition** — factor predictions into sub-problems when beneficial
+
+The validation architecture is detailed in [the validation framework](../shared/validation-framework.md). Feature engineering patterns are in [feature engineering](../shared/feature-engineering.md). Loss function design is covered in [loss design](../shared/loss-design.md).
+
+---
+
+## Entry Point
+
+Begin the conversation with the builder by asking:
+
+> **What are you predicting, and why?**
+>
+> Specifically:
+> 1. What is the prediction target? (e.g., future returns, volatility, funding rate, spread, sentiment score)
+> 2. What is the prediction horizon? (e.g., 1 hour, 8 hours, 1 day, 1 week)
+> 3. What asset(s) or instrument(s)?
+> 4. What is your hypothesis — why do you believe this target is predictable, and what do you think drives it?
+
+The builder's answers to these questions determine everything that follows. Do not proceed until you have clear answers to all four.
+
+---
+
+## Guided Workflow
+
+### Step 1: Define the Prediction Problem
+
+From the builder's answers, establish:
+
+- **Target variable.** The exact quantity being predicted. Be precise: "log-returns over the next H periods" is different from "price direction" or "excess returns relative to a benchmark." The target definition determines what the loss function optimizes and what validation metrics are appropriate.
+
+- **Prediction horizon `H`.** In the data's native time units. All temporal parameters in the pipeline will be derived from this value (Principle 2).
+
+- **Data sources.** What data is available? Price/volume (which exchange, which pair), on-chain data, alternative data, social data? The data sources constrain what features are constructible.
+
+- **Hypothesis formalization.** Translate the builder's theory into testable claims. "I think momentum predicts returns" becomes "short-term price trends over the past ~0.5H to 2H periods carry information about returns over the next H periods." This formalization reveals what estimation goals the features must serve.
+
+**Output from this step:** A structured problem definition that the builder confirms before proceeding.
+
+#### Checkpoint 1
+> Before proceeding, confirm with the builder:
+> - Is the target variable precisely defined?
+> - Is the prediction horizon concrete (a specific number in specific time units)?
+> - Are the data sources identified and accessible?
+> - Is the hypothesis specific enough to suggest what features to build?
+
+---
+
+### Step 2: Identify Estimation Goals
+
+This step translates the builder's hypothesis into a structured set of **estimation goals** — the economic or physical quantities that features will estimate (Principle 1: physics-first feature engineering).
+
+Guide the builder through this reasoning:
+
+1. **What does your hypothesis claim drives the target?** Each claimed driver maps to one or more estimation goals. If the hypothesis is "momentum and volatility regime predict returns," the estimation goals are: (a) momentum at various timescales, (b) current volatility regime.
+
+2. **What additional quantities might be informative?** Beyond the primary hypothesis, are there standard quantities relevant to this prediction problem? For example, if predicting returns, the current volatility level is almost always relevant (even if not part of the primary hypothesis) because it affects the signal-to-noise ratio.
+
+3. **For each estimation goal, what data sources and computation approaches could estimate it?** A "momentum" goal could be estimated by return over a lookback window, moving average slope, exponential moving average ratio, or many other approaches. The builder chooses based on their beliefs about which estimator best captures the quantity.
+
+4. **Are there natural sub-problems?** (Principle 9: problem decomposition.) Could the prediction be improved by decomposing the target into components and modeling them separately? For example, predicting conditional mean and conditional variance separately. Only pursue decomposition if the builder has a reason to believe the sub-problems are more tractable than the joint problem.
+
+**Output from this step:** A list of estimation goals, each with:
+- The quantity being estimated
+- Why it is relevant to the prediction target (connection to the hypothesis)
+- Candidate computation approaches
+- Which data sources it requires
+
+---
+
+### Step 3: Construct Features
+
+For each estimation goal, construct concrete features. This step implements Principles 1 (physics-first), 2 (horizon-adaptive), and 3 (lookahead prevention).
+
+Guide the builder through these decisions for each feature:
+
+**Horizon-adaptive parameterization.** Every temporal parameter must be expressed as a multiple of `H`. Work with the builder to choose meaningful multipliers:
+- What timescale relative to `H` does this estimation goal operate at?
+- Should this feature capture dynamics shorter than `H` (fraction multiplier), at the scale of `H` (multiplier ~1), or longer than `H` (larger multiplier)?
+- For features with multiple period parameters (e.g., a ratio of two moving averages), how should the periods relate to each other and to `H`?
+
+**Lookahead prevention.** For each feature, verify:
+- Is the computation strictly past-looking? (No future data used, no full-sample statistics.)
+- Are rolling/expanding windows correctly bounded?
+- After feature computation, will raw data columns (prices, volumes, etc.) be dropped from model input?
+
+**Feature rationale.** Each feature must have a documented connection to an estimation goal. No "kitchen sink" features.
+
+**Output from this step:** A feature specification — for each feature:
+- Name and description
+- Estimation goal it serves
+- Computation method (in terms of data columns and horizon-adaptive periods)
+- Period multipliers relative to `H`
+
+Then write the feature engineering code:
+- A function or class that takes raw data and the prediction horizon `H` as inputs
+- Computes all features using only past data
+- Returns a clean feature DataFrame with no raw columns
+- All temporal parameters derived from `H`
+
+#### Checkpoint 2
+> Before proceeding, verify with the builder:
+> - Every feature has a stated estimation goal
+> - All temporal parameters are expressed as multiples of `H`
+> - No feature uses future data (review each computation)
+> - Raw data columns are excluded from model input
+> - If decomposition is used, each sub-problem has its own feature set
+
+---
+
+### Step 4: Design the Loss Function
+
+The loss function encodes the builder's beliefs about what constitutes a good prediction (Principle 5). This is a modeling decision, not a default.
+
+Guide the builder through these considerations:
+
+1. **What matters most — direction, magnitude, or both?** If the application primarily needs directional accuracy (e.g., a binary trading signal), the loss should emphasize directional correctness. If magnitude matters (e.g., position sizing), the loss should penalize magnitude errors appropriately.
+
+2. **Is the target heteroscedastic?** If the target's variance changes over time (common in financial data), should the loss normalize by local volatility? Volatility-normalized losses produce predictions calibrated to current market conditions rather than historical averages.
+
+3. **How should outliers be handled?** Financial data has fat tails. Squared-error losses are heavily influenced by extreme observations. Consider whether the loss should be robust to outliers (e.g., Huber loss, Cauchy-tailed losses) or whether extreme observations carry important signal.
+
+4. **Are there asymmetric costs?** Is being wrong in one direction more costly than being wrong in the other? If so, the loss should reflect this asymmetry.
+
+5. **For log-returns targets specifically:** Consider the CZAR (Composite Zero-Agnostic Returns) loss — a piecewise loss built on the Cauchy kernel that z-scores by local volatility, applies steep wrong-sign penalties, uses bounded arctan transitions for same-sign predictions, and smoothly reduces loss near zero returns. See [loss design](../shared/loss-design.md) for the full mathematical structure, parameters, and implementation details.
+
+**Output from this step:** A loss function implementation with documented rationale for each design choice.
+
+#### Checkpoint 3
+> Before proceeding, verify with the builder:
+> - The loss function aligns with what the builder actually cares about (direction, magnitude, calibration)
+> - Design choices are intentional, not defaults
+> - If using custom loss components, each has a clear motivation
+
+---
+
+### Step 5: Design the Validation Pipeline
+
+Build the three-stage validation architecture (Principle 4) with multi-threshold quality gates (Principle 6) and optimizer-gaming prevention (Principle 7). See [the validation framework](../shared/validation-framework.md) for full details.
+
+Guide the builder through these decisions:
+
+**Inner CV design (Stage 1):**
+- Walk-forward fold structure: expanding or sliding window?
+- Number of folds (enough test samples per fold for statistical significance)
+- Gap buffer size: at least `max(H, max_feature_lookback)` — compute this from the feature specification
+- Validation set sizing: match test set size (validation-test parity)
+- Hyperparameter search strategy: what parameters to search, what ranges, what search method
+
+**Outer evaluation design (Stage 2):**
+- How to partition data between inner and outer portions
+- Number of outer evaluation windows
+- Constant total test coverage: `num_windows * window_size = const_test_epochs`
+
+**Quality gates:**
+Work with the builder to define thresholds for each gate. These should reflect what would make the model useful in practice:
+- Directional accuracy threshold (above chance — what is the baseline for this target?)
+- Statistical significance level (typically p < 0.05, with confidence intervals)
+- Calibration requirement (monotonic relationship between prediction magnitude and actual magnitude)
+- Financial improvement threshold (above a specified baseline, using a metric appropriate to the application)
+
+**Output from this step:** Validation pipeline code implementing:
+- Purged walk-forward CV with correctly sized gap buffers
+- Three-stage data partitioning
+- All quality gates with builder-specified thresholds
+- Validation-test parity and constant test coverage
+
+#### Checkpoint 4
+> Before proceeding, verify with the builder:
+> - Gap buffer size >= max(H, max_feature_lookback)
+> - Outer evaluation windows do not overlap with inner CV data
+> - Validation set size equals test set size
+> - All quality gates have defined thresholds
+> - Thresholds were set based on practical requirements, not current model performance
+
+---
+
+### Step 6: Build the Configuration
+
+Assemble all decisions into a configuration specification (Principle 8). The config is the single source of truth for the experiment.
+
+The configuration must include:
+
+```yaml
+# Prediction problem
+target:
+  name: <what is being predicted>
+  horizon_bars: <H, number of bars>
+  asset: <asset identifier>
+
+# Data source
+data:
+  exchange: <exchange name>
+  interval: <bar size>
+  start: <earliest data to use>
+  end: <latest data to use, or "latest">
+
+# Three-stage partition boundaries
+partitions:
+  optimization_end: <end of optimization period>
+  evaluation_end: <end of evaluation period>
+  deployment_end: <end of deployment period>
+  gap_bars: <gap buffer size in bars>
+
+# Features grouped by estimation goal
+features:
+  <estimation_goal>:
+    - name: <feature name>
+      window: <lookback in bars, as multiple of H>
+      description: <what this measures>
+
+# Model architecture
+model:
+  type: <model type>
+  task: <regression or classification>
+
+# Loss function (top-level, not inside model)
+loss:
+  name: <loss function name>
+  <loss-specific parameters>
+
+# Baseline loss for comparison
+comparison_loss: <baseline loss name>
+
+# Hyperparameter search
+hyperparameter_search:
+  method: <search method>
+  params:
+    <param_name>: <search values>
+
+# Walk-forward cross-validation (Stage 1)
+walk_forward_cv:
+  n_folds: <number>
+  expanding_window: <true or false>
+  gap_bars: <gap buffer size>
+
+# Quality gates
+gates:
+  <gate_name>:
+    threshold: <threshold value>
+
+# Output
+output_dir: <path>
+```
+
+**Output from this step:** A complete YAML configuration file.
+
+---
+
+### Step 7: Implement the Pipeline
+
+With the specification complete, build the end-to-end pipeline. The implementation consists of these modules:
+
+**1. Config loader.** Reads the YAML config. All downstream code references the config — no hardcoded values.
+
+**2. Data loader.** Fetches data from specified sources, handles missing values, aligns timestamps, and produces a clean DataFrame. Must handle the builder's specific data sources.
+
+**3. Feature engineer.** Implements the feature specification from Step 3. Takes raw data and `H`, returns computed features with raw columns dropped. All temporal parameters derived from `H` via the config multipliers.
+
+**4. Target constructor.** Computes the target variable with the appropriate shift. The shift is applied once, globally, derived from `H`. This is the single point of truth for target alignment.
+
+**5. Model and loss.** Implements the model architecture and custom loss function from Step 4. The model takes features as input and produces predictions of the target.
+
+**6. Validation pipeline.** Implements the three-stage architecture from Step 5:
+   - Stage 1: Inner purged walk-forward CV with hyperparameter search
+   - Stage 2: Outer evaluation on independent windows with multi-threshold quality gates
+   - Deployment validation: retrain on all pre-deployment data, evaluate on a held-out deployment set with the same quality gates
+   - Stage 3: Full-data retrain for deployment (only if deployment validation passes)
+
+**7. Evaluation report.** After running the pipeline, produces a summary:
+   - Per-fold inner CV results
+   - Outer evaluation results per window
+   - Quality gate pass/fail for each gate
+   - Overall pass/fail determination
+   - Confidence intervals for key metrics
+
+Guide the builder through implementing each module. For each module:
+- Write the code together
+- Verify it respects all applicable principles
+- Test it on sample data before moving to the next module
+
+#### Checkpoint 5
+> Before running the full pipeline, verify:
+> - Config is complete and all code reads from it (no hardcoded parameters)
+> - Feature engineer uses only past data and drops raw columns
+> - Target shift is applied once, globally
+> - Gap buffers in CV are correctly sized
+> - Validation pipeline implements all three stages
+> - Quality gates check all criteria simultaneously
+> - No data leaks between stages (inner data strictly earlier than outer data)
+
+---
+
+### Step 8: Run and Evaluate
+
+Execute the full pipeline and interpret results.
+
+**If the model passes all quality gates on the evaluation set:**
+- Run deployment validation: retrain on all pre-deployment data (optimization + evaluation, minus gap buffer) using the frozen hyperparameters. Evaluate on the held-out deployment set with the same quality gates. This catches models that pass evaluation but do not generalize further.
+- If deployment validation fails: diagnose the gap between evaluation and deployment performance. Do NOT relax gate thresholds. The failure handling guidance below applies.
+- If deployment validation passes:
+  - Report the results with confidence intervals. Discuss with the builder: are the results consistent with the hypothesis? Which estimation goals appear most predictive?
+  - Proceed to Stage 3 (full-data retrain) for deployment: retrain on all available data using the frozen hyperparameters from Stage 1
+  - Design post-deployment monitoring. The builder should define:
+    - **Performance monitoring:** Track live predictions against realized outcomes. Define a threshold for when live performance has degraded enough to trigger re-evaluation (e.g., rolling directional accuracy dropping below the quality gate threshold over a monitoring window).
+    - **Feature monitoring:** Track feature distributions. If the distribution of any feature drifts significantly from what was seen in training, the model may be operating outside its valid regime.
+    - **Staleness check:** Define a maximum model age. Even if performance has not degraded, the model should be periodically re-validated on fresh data.
+    - **Rebuild trigger:** At what threshold does degradation trigger a full rebuild? Does the rebuild use the same validation framework, or should gates be revisited?
+
+**If the model fails one or more quality gates:**
+- Identify which gates failed and by how much
+- Diagnose: is the hypothesis wrong, or is the implementation insufficient?
+  - Failed directional accuracy: the features may not carry the predicted signal. Revisit the hypothesis and estimation goals (Step 2).
+  - Failed significance: there may be signal but not enough data to detect it. Consider longer history or more outer evaluation windows.
+  - Failed calibration: the model may have the right direction but wrong magnitudes. Revisit the loss function (Step 4).
+  - Failed financial improvement: the signal may exist but be too weak to overcome transaction costs or improve on a simple baseline. Consider whether the prediction problem is tractable.
+- The builder decides whether to iterate (return to the appropriate step) or pivot to a different hypothesis.
+
+**Do not adjust quality gate thresholds to make the model pass.** If the model does not meet the bar, the honest answer is that the model is not good enough — yet. Lowering the bar does not make the model better; it makes the evaluation worse.
+
+---
+
+## Output Specification
+
+A completed hypothesis-driven pipeline produces these artifacts:
+
+| Artifact | Description |
+|---|---|
+| `config.yaml` | Complete experiment specification — prediction target, horizon, features, model, validation parameters |
+| `data_loader.py` | Fetches and preprocesses data from specified sources |
+| `feature_engineer.py` | Computes features from raw data, horizon-adaptive, no lookahead |
+| `model.py` | Model architecture and custom loss function |
+| `validation.py` | Three-stage validation pipeline with multi-threshold quality gates |
+| `evaluate.py` | Pipeline orchestrator: load data, compute features, run three-stage validation, report results |
+| `evaluation_report.md` | Results summary: per-gate pass/fail, confidence intervals, interpretation |
+| `monitor.py` | Post-deployment monitoring: performance tracking, feature drift detection, staleness checks |
+
+Each artifact must be self-contained and runnable. The builder should be able to modify the config and re-run the pipeline without changing code.
+
+---
+
+## Principles Checklist
+
+Before declaring the pipeline complete, verify every principle is satisfied:
+
+| # | Principle | How to verify |
+|---|---|---|
+| 1 | Physics-first features | Every feature has a documented estimation goal |
+| 2 | Horizon-adaptive | All temporal parameters are `multiplier * H` in the config |
+| 3 | No lookahead | Features use past-only computation; raw columns dropped; gap buffers in CV |
+| 4 | Three-stage separation | Inner CV, outer evaluation, and production retrain are distinct stages with no data leakage |
+| 5 | Loss as modeling decision | Loss function design choices are documented and intentional |
+| 6 | Multi-threshold validation | All quality gates are implemented and must pass simultaneously |
+| 7 | Optimizer-gaming prevention | val_size = test_size; constant total test coverage across configurations |
+| 8 | Configuration-driven | All parameters in config.yaml; new experiment = new config, not new code |
+| 9 | Problem decomposition | Builder considered whether decomposition is appropriate; decision is documented |

--- a/allora_research_model_skills/robustness-first/SKILL.md
+++ b/allora_research_model_skills/robustness-first/SKILL.md
@@ -1,0 +1,466 @@
+---
+name: forge-robustness-first
+description: >
+  Guide creation of a prediction model for Allora using robustness-first development methodology.
+  Produces a complete pipeline: data loading, feature engineering, model training, and validation.
+disable-model-invocation: true
+---
+
+# Robustness-First Model Development
+
+You are guiding a builder through creating a prediction model using robustness-first methodology. The builder's core concern is generalization — they want maximum confidence that what they build is real, not an artifact of overfitting.
+
+**Your character:** Adversarial and defensive. You are the builder's skeptical partner. Every design choice must justify itself against the question: "How do I know this isn't overfit?" Push back on complexity that doesn't earn its keep. Demand evidence at every stage.
+
+Before starting, read the shared methodology documents:
+- `../shared/methodology.md` — Nine principles that govern this workflow
+- `../shared/validation-framework.md` — Three-stage separation and quality gates
+- `../shared/feature-engineering.md` — Horizon-adaptive construction and lookahead prevention
+- `../shared/loss-design.md` — Loss function design as a modeling decision
+
+---
+
+## Phase 0: Define the Adversary
+
+Start with this question:
+
+> **How will you know your model is real and not overfit?**
+
+Do not let the builder proceed until they can articulate what "real" means for their problem. This is not philosophical — it determines every downstream decision.
+
+Guide them through:
+
+1. **What are you predicting?** Get the specific prediction target and time horizon. Examples: 8-hour log-returns, daily realized volatility, next-funding-rate. The target determines what features are admissible and what validation is meaningful.
+
+2. **What would a fake model look like?** Have the builder enumerate the failure modes they are defending against:
+   - Overfitting to training data noise
+   - Lookahead contamination (future information leaking into features)
+   - Regime-specific performance (works in one market condition, fails in others)
+   - Optimizer gaming (model learns to exploit validation set structure)
+   - Data snooping (too many features tried, some correlate by chance)
+
+3. **What evidence would convince a skeptic?** The builder must specify concrete, falsifiable criteria — not vague aspirations like "good Sharpe ratio." Push for:
+   - Specific metrics with specific thresholds
+   - Out-of-sample requirements
+   - Stability conditions (performance should not collapse when parameters shift slightly)
+
+**Checkpoint:** The builder has a prediction target, a list of failure modes to defend against, and concrete criteria for what "real" means. Record these — they become the quality gates.
+
+---
+
+## Phase 1: Design the Validation Framework
+
+Build the defense before building the model. This is the inversion that defines robustness-first development: you design the test your model must pass before you design the model.
+
+### Step 1.1: Establish Three-Stage Separation
+
+The builder must define three non-overlapping temporal partitions of their data:
+
+- **Optimization set** — Used for training and hyperparameter search. The model sees this data.
+- **Evaluation set** — Used for model selection and gate checks. The model never trains on this data, but the builder uses it to make decisions (which model to keep, which features to include).
+- **Deployment set** — Held out completely. Used exactly once for validation at the end, to verify that evaluation-set performance was not an artifact of the builder's own selection process. (The deployment data is later included in the full-data retrain with frozen hyperparameters — this does not compromise the validation because no decisions are made after the deployment gates.)
+
+Key constraints the builder must satisfy:
+- Temporal ordering: optimization period comes first, then evaluation, then deployment. No shuffling. Financial data is non-stationary; random splits destroy temporal structure.
+- The evaluation and deployment sets should be equal in length. If they differ substantially, the deployment check loses statistical power.
+- All three periods should contain a representative mix of market conditions (trending, mean-reverting, volatile, calm). If one period is entirely bull-market, results are meaningless. The builder should inspect the data to verify this.
+
+Ask the builder to specify exact date boundaries for each partition and justify that each period contains diverse market conditions.
+
+### Step 1.2: Define Quality Gates
+
+Quality gates are the concrete criteria from Phase 0 translated into computable checks. Each gate is independent — the model must pass ALL of them simultaneously, not just on average.
+
+Guide the builder to define gates across multiple dimensions:
+
+**Predictive performance gates:**
+- Primary metric appropriate to the prediction target (e.g., directional accuracy, rank correlation, mean squared error)
+- The threshold must be above what a trivial baseline achieves. Have the builder compute the baseline first: what does "predict the mean" or "predict zero" score?
+
+**Stability gates:**
+- Performance must not collapse in any contiguous sub-period of the evaluation set. Define sub-period length (e.g., monthly).
+- The worst sub-period performance must exceed a minimum threshold — not just the average.
+
+**Robustness gates:**
+- Sensitivity to hyperparameters: if changing a hyperparameter by 10-20% causes a large performance drop, the model is fragile, not robust.
+- Feature importance stability: the model should not rely entirely on a single feature. If removing any one feature destroys performance, the model is brittle.
+
+**Regime gates (if applicable):**
+- If the builder identified regime-specific failure as a risk, define minimum performance per regime (e.g., separate thresholds for high-volatility vs. low-volatility periods).
+
+Ask the builder to write these gates as executable checks — functions that take predictions and actuals and return pass/fail. These are code, not aspirations.
+
+**Checkpoint:** The builder has a three-stage data partition with justified boundaries, and a set of executable quality gates covering predictive performance, stability, and robustness. No model code has been written yet.
+
+---
+
+## Phase 2: Reason Backwards to Architecture
+
+Now that the builder knows what their model must survive, work backwards. The validation framework constrains what kind of model is worth building.
+
+### Step 2.1: What Could Pass These Gates?
+
+Guide the builder to reason about their gates:
+
+- If stability gates require consistent monthly performance, the model cannot be one that makes a few large bets — it needs to generate signal across time. This constrains both the feature design and the model class.
+- If robustness gates require hyperparameter insensitivity, the model should be relatively simple or well-regularized. Deep architectures with many tunable parameters are harder to stabilize.
+- If regime gates require cross-regime performance, the features must capture regime-relevant information (e.g., volatility level, trend strength) so the model can adapt.
+
+The builder should write down: given my gates, what properties must my model have? This narrows the design space before any code is written.
+
+### Step 2.2: Design Features to Survive Validation
+
+Features must be designed with the validation framework in mind, not the other way around.
+
+Guide the builder through feature construction using the principles in `../shared/feature-engineering.md`:
+
+1. **Organize features around estimation goals.** Each feature should address a specific aspect of the prediction problem (e.g., momentum, volatility regime, mean-reversion tendency). The builder should name each estimation goal and list the features that serve it.
+
+2. **Derive all time periods from the prediction horizon.** If the prediction horizon is H, feature lookback windows should be multiples or fractions of H. This ensures features are scaled to the decision frequency. Avoid arbitrary lookback windows (e.g., "20-day moving average" when predicting 8-hour returns).
+
+3. **Prevent lookahead by architecture.** Every feature must be computable using only data available at prediction time. This is not just about being careful — build structural guardrails:
+   - Features should be computed from data indexed by timestamps strictly before the prediction time.
+   - Normalization statistics (means, standard deviations) must be computed on training data only, then applied to evaluation and deployment data without re-fitting.
+   - If using rolling statistics, the window must not extend into the future.
+
+   The builder should write a `validate_no_lookahead()` function that programmatically verifies these constraints.
+
+4. **Keep the feature set parsimonious.** More features increase the risk of data snooping. Each feature must have a clear reason to exist (tied to an estimation goal). If the builder cannot articulate why a feature should help, it should not be included.
+
+### Step 2.3: Select Model Architecture
+
+The model class should be chosen to satisfy the properties identified in Step 2.1, not based on what is trendy.
+
+Guide the builder to consider:
+- How many features do they have? With few features, simple models (linear, shallow tree ensembles) are often more robust.
+- Do they need the model to be interpretable to diagnose gate failures? Transparent models make debugging easier.
+- What is the effective sample size relative to the model's capacity? Overparameterized models are harder to validate.
+
+The builder should justify their choice against the gate requirements, not against benchmarks.
+
+**Checkpoint:** The builder has a feature design organized by estimation goal with horizon-derived periods, structural lookahead prevention, and a model architecture chosen to satisfy the gate requirements. No training has occurred.
+
+---
+
+## Phase 3: Design Loss Toward the Gates
+
+The loss function is a modeling decision, not an afterthought. See `../shared/loss-design.md` for the full treatment.
+
+Guide the builder to align their loss function with their quality gates:
+
+1. **What does the primary gate measure?** The loss function should optimize for something related to (but not identical to) the primary gate metric. If the gate measures directional accuracy, the loss should encourage correct sign prediction. If the gate measures rank correlation, the loss should encourage correct ordering.
+
+2. **Does the loss encode domain beliefs?** For specific prediction targets, specialized loss functions can encode structural knowledge about the problem. For example, when predicting log-returns, asymmetric penalties can encode beliefs about the relative cost of over- vs. under-prediction. The builder should articulate what beliefs their loss encodes.
+
+3. **Does the loss encourage robustness?** Some loss functions are more robust to outliers than others. If stability gates require consistent performance, the loss should not be dominated by a few extreme observations. Consider robust alternatives (Huber loss, quantile losses) if the target distribution has heavy tails.
+
+4. **Test loss sensitivity.** Train with the chosen loss and at least one alternative. If the gate outcomes are highly sensitive to loss choice, the builder should understand why. This is diagnostic information about the problem, not just a hyperparameter.
+
+**Checkpoint:** The builder has a loss function chosen deliberately to align with their quality gates and encode domain beliefs, with at least one alternative tested for comparison.
+
+---
+
+## Phase 4: Build the Pipeline
+
+Now — and only now — the builder writes the complete pipeline. Every component has been designed to survive the validation framework. The builder is implementing a plan, not exploring.
+
+### Step 4.1: Configuration Specification
+
+The entire pipeline should be driven by a configuration file. Every knob the builder might turn — data source, date ranges, feature parameters, model hyperparameters, validation thresholds — goes in the config.
+
+This serves two purposes:
+- **Reproducibility:** Any result can be reproduced by re-running with the same config.
+- **Experimentation:** Trying a different feature parameterization means changing a config value, not editing code.
+
+Guide the builder to write the config first, then implement the code that reads it.
+
+The config should follow this structure:
+
+```yaml
+# Prediction problem
+target:
+  name: <what is being predicted>
+  horizon_bars: <H, number of bars>
+  asset: <asset identifier>
+
+# Data source
+data:
+  exchange: <exchange name>
+  interval: <bar size>
+  start: <earliest data to use>
+  end: <latest data to use>
+
+# Three-stage partition boundaries
+partitions:
+  optimization_end: <end of optimization period>
+  evaluation_end: <end of evaluation period>
+  deployment_end: <end of deployment period>
+  gap_bars: <gap buffer size in bars>
+
+# Features grouped by estimation goal
+features:
+  <estimation_goal>:
+    - name: <feature name>
+      window: <lookback in bars, as multiple of H>
+      description: <what this measures>
+
+# Model architecture
+model:
+  type: <model type>
+  task: <regression or classification>
+
+# Loss function (top-level, not inside model)
+loss:
+  name: <loss function name>
+  <loss-specific parameters>
+
+# Baseline loss for comparison
+comparison_loss: <baseline loss name>
+
+# Hyperparameter search
+hyperparameter_search:
+  method: <search method>
+  params:
+    <param_name>: <search values>
+
+# Walk-forward cross-validation (Stage 1)
+walk_forward_cv:
+  n_folds: <number>
+  expanding_window: <true or false>
+  gap_bars: <gap buffer size>
+
+# Quality gates
+gates:
+  <gate_name>:
+    threshold: <threshold value>
+
+# Output
+output_dir: <path>
+```
+
+### Step 4.2: Implement Pipeline Components
+
+Guide the builder to implement each component as a standalone module:
+
+1. **Data loader** — Fetches and caches raw data. Validates data quality (missing values, gaps, timezone consistency). Outputs a clean, time-indexed dataset.
+
+2. **Feature engineer** — Reads the clean dataset and config. Computes all features. Applies the `validate_no_lookahead()` check. Outputs a feature matrix with timestamps.
+
+3. **Model and loss** — Defines the model class and loss function. Training uses only the optimization set. All normalization statistics computed from the optimization set are frozen and applied to other sets without re-fitting.
+
+4. **Validation suite** — Implements all quality gates as executable functions. Takes predictions and actuals, returns a structured pass/fail report for each gate. This was designed in Phase 1 — now it becomes code.
+
+5. **Evaluation runner** — Orchestrates the full pipeline: load data, compute features, train on optimization set, predict on all three sets, run quality gates. Outputs a structured evaluation report.
+
+Each module should be independently testable. The builder should be able to run the feature engineer on test data and verify outputs without running the full pipeline.
+
+### Step 4.3: Pipeline Integrity Checks
+
+Before running training, verify pipeline integrity:
+
+- **Data partition correctness:** Confirm no overlap between optimization, evaluation, and deployment date ranges.
+- **Lookahead check:** Run `validate_no_lookahead()` on the full feature matrix.
+- **Feature-target alignment:** Verify that features at time t are used to predict targets at time t + H (not time t).
+- **Normalization isolation:** Verify that normalization statistics are computed only from optimization-set data.
+
+These checks should be automated and run every time the pipeline executes — not just during development.
+
+**Checkpoint:** The builder has a complete, config-driven pipeline with data loader, feature engineer, model+loss, validation suite, and evaluation runner. All components are modular and independently testable. Integrity checks are automated.
+
+---
+
+## Phase 5: Execute Three-Stage Validation
+
+Run the pipeline through the three-stage methodology. This is where the builder's design is tested against reality.
+
+### Step 5.1: Optimization Stage
+
+Train the model on the optimization set. This is the only stage where the model sees data.
+
+- Run training with the chosen loss function.
+- Record optimization-set performance as a reference (this is expected to be the best performance — if evaluation-set performance exceeds it, something is wrong).
+
+### Step 5.2: Evaluation Stage
+
+Apply the trained model to the evaluation set. Run all quality gates.
+
+**If gates pass:** Proceed to Step 5.3. Do not celebrate yet — evaluation-set performance may still reflect the builder's own selection bias (they designed the features and model knowing they would be tested here).
+
+**If gates fail:** This is the critical moment. The builder must decide:
+
+- **Diagnose, do not patch.** Examine which gates failed and why. Is it a specific sub-period? A specific feature? A regime shift? Understanding the failure is more valuable than fixing it.
+- **If modifying the model or features:** The builder is now using the evaluation set to make decisions. This is acceptable (the evaluation set exists for this purpose), but it means the deployment set becomes the only unbiased check. Track how many evaluation-guided iterations occur — excessive iteration erodes the evaluation set's independence.
+- **If tempted to relax the gates:** Resist. The gates were set before seeing any results. Relaxing them after failure is the definition of overfitting to the evaluation set. If the gates were genuinely too strict, the builder must articulate why before any change.
+- **Never re-partition the data to get better results.** The partition was fixed in Phase 1. Changing it is a form of data snooping.
+
+### Step 5.3: Deployment Validation
+
+Before committing to a full-data retrain, validate that the model generalizes beyond the evaluation set. Retrain the model on all pre-deployment data (optimization set + evaluation set, minus gap buffer) using the frozen hyperparameters from Stage 1. Then evaluate on the deployment set using the same quality gates as Stage 2.
+
+This retrain is critical: the model evaluated in Step 5.2 was trained only on the optimization set. Deployment validation retrains on the larger dataset (optimization + evaluation) to test whether the model generalizes when given more training data — not just whether the same model scores well on a different period.
+
+This is a one-shot test. The builder has exactly one chance:
+
+- **If gates pass:** The model has survived. The deployment-set results are the best estimate of real-world performance.
+- **If gates fail:** The model does not generalize. The gap between evaluation and deployment performance quantifies the builder's own selection bias during development. Do NOT relax gate thresholds.
+
+Record all results — deployment-set performance is the number the builder reports, not evaluation-set performance.
+
+### Step 5.4: Document the Run
+
+The builder must produce a complete evaluation report containing:
+
+- Config used (exact, frozen, reproducible)
+- Optimization-set performance
+- Evaluation-set gate results (pass/fail for each gate)
+- Number of evaluation-guided iterations (how many times the builder went back and modified the model after seeing evaluation results)
+- Deployment-set gate results (pass/fail for each gate)
+- Performance comparison across all three stages
+- Any anomalies or concerns
+
+**Checkpoint:** The builder has executed the full three-stage validation with documented results. If deployment gates passed, the model is a candidate for deployment. If they failed, the builder has diagnostic information about what went wrong.
+
+---
+
+## Phase 6: Prepare for Deployment
+
+If — and only if — deployment gates passed, prepare the model for live use.
+
+### Step 6.1: Full-Data Retrain
+
+The three-stage methodology requires a final retrain before deployment. The hyperparameters were selected in Stage 1 and validated in Stage 2 — they are now frozen. Retrain the model on **all available data** (optimization + evaluation + deployment sets) using those frozen hyperparameters. This maximizes the amount of training data the deployed model has seen, without any risk of overfitting hyperparameters to the evaluation or deployment sets (those were only used to validate the already-frozen configuration).
+
+The deployed model is this full-data retrain — not the model from Stage 2.
+
+### Step 6.2: Freeze the Pipeline
+
+- Lock the config file. No further changes.
+- Lock all code and the retrained model weights.
+- Record the git commit hash (or equivalent) that corresponds to the validated pipeline.
+
+### Step 6.3: Define Monitoring
+
+The quality gates do not stop at deployment. The builder should define ongoing monitoring checks:
+
+- **Performance monitoring:** Track live predictions against realized outcomes. Define a threshold for when live performance has degraded enough to trigger re-evaluation.
+- **Feature monitoring:** Track feature distributions. If the distribution of any feature drifts significantly from what was seen in training, the model may be operating outside its valid regime.
+- **Staleness check:** Define a maximum age for the model. Even if performance has not degraded, the model should be periodically re-validated on fresh data.
+
+### Step 6.4: Define the Rebuild Trigger
+
+When monitoring detects degradation, what happens? The builder should define:
+- At what threshold does degradation trigger a full rebuild?
+- Does the rebuild use the same validation framework, or should gates be revisited?
+- How is new data incorporated into the three-stage partition?
+
+---
+
+## Output Artifacts
+
+At the end of this workflow, the builder must have produced the following complete, runnable artifacts:
+
+| Artifact | Description |
+|----------|-------------|
+| `config.yaml` | Complete pipeline configuration: target, horizon, data source, partition boundaries, feature definitions, model hyperparameters, loss specification, quality gate definitions and thresholds |
+| `data_loader.py` | Data fetching, caching, quality validation. Reads config, outputs clean time-indexed dataset |
+| `feature_engineer.py` | Feature computation organized by estimation goal, with horizon-derived parameters and automated lookahead prevention checks |
+| `model.py` | Model definition, loss function, training loop. Normalization statistics frozen from optimization set |
+| `validation.py` | Quality gates as executable functions. Takes predictions and actuals, returns structured pass/fail report |
+| `evaluate.py` | Pipeline orchestrator. Runs full three-stage evaluation, outputs structured report |
+| `evaluation_report.md` | Complete results: per-stage performance, gate outcomes, iteration count, anomalies |
+| `monitor.py` | Post-deployment monitoring: performance tracking, feature drift detection, staleness checks |
+
+Every artifact must be runnable. The config file must fully reproduce the evaluation results. The builder should be able to hand this package to someone else and they should be able to reproduce the results without additional context.
+
+---
+
+## Decision Flowchart
+
+At each phase, the builder faces decisions. Here is the logic that governs them:
+
+```
+Define what "real" means
+    │
+    ▼
+Design quality gates (concrete, executable)
+    │
+    ▼
+Reason: what model properties satisfy these gates?
+    │
+    ▼
+Design features and architecture to match
+    │
+    ▼
+Choose loss function aligned with gates
+    │
+    ▼
+Build config-driven pipeline
+    │
+    ▼
+Run integrity checks ──── FAIL → fix before proceeding
+    │
+    ▼
+Train on optimization set
+    │
+    ▼
+Evaluate on evaluation set
+    │
+    ├── Gates FAIL → diagnose (do not patch)
+    │       │
+    │       ├── Root cause understood → modify and re-evaluate
+    │       │       (track iteration count)
+    │       │
+    │       └── Root cause unclear → reconsider problem setup
+    │
+    └── Gates PASS
+            │
+            ▼
+        Retrain on opt+eval, validate on deployment set (one shot)
+            │
+            ├── Gates FAIL → model does not generalize
+            │       │
+            │       └── Gap quantifies builder selection bias
+            │
+            └── Gates PASS → model is a deployment candidate
+                    │
+                    ▼
+                Freeze pipeline, define monitoring, ship
+```
+
+---
+
+## Problem Decomposition
+
+Before committing to a single monolithic model, consider whether the prediction problem can be decomposed into sub-problems that are individually easier to model.
+
+**When to decompose:**
+- The target variable has distinct regimes that respond to different drivers (e.g., trending vs. mean-reverting markets may need different feature sets).
+- The target can be factored into components with different predictability characteristics.
+- Different time horizons within the target respond to different signals.
+
+**When NOT to decompose:**
+- Decomposition introduces coupling between sub-models that is hard to validate.
+- The sub-problems are not independently testable — if you cannot validate a sub-model in isolation, decomposition adds complexity without adding rigor.
+- The recombination function introduces its own failure modes that are harder to diagnose than the original problem.
+
+**If decomposing:** Apply the entire robustness-first workflow to each sub-model independently. Each sub-model gets its own quality gates, its own three-stage validation, and its own deployment decision. The recombination logic is then validated as a separate model with the sub-model outputs as features.
+
+The validation framework you designed in Phase 1 applies to the combined output. If sub-models individually pass their gates but the combined output fails, the recombination logic is the problem — not the sub-models.
+
+---
+
+## Principles Checklist
+
+Before considering the pipeline complete, verify that all nine principles have been applied:
+
+- [ ] **Physics-first feature engineering** — Features organized around named estimation goals, not arbitrary indicators
+- [ ] **Horizon-adaptive parameterization** — All lookback windows and time periods derived from the prediction horizon
+- [ ] **Lookahead prevention by architecture** — Structural guardrails (automated checks, timestamp discipline), not just developer care
+- [ ] **Three-stage separation** — Optimize, evaluate, deploy with non-overlapping temporal partitions
+- [ ] **Loss function as modeling decision** — Loss chosen deliberately to align with gates and encode domain beliefs
+- [ ] **Multi-threshold signal validation** — Multiple independent quality gates, all must pass simultaneously
+- [ ] **Optimizer-gaming prevention** — Evaluation and deployment sets are equal-length; deployment set used for validation exactly once (subsequent inclusion in full-data retrain uses frozen hyperparameters)
+- [ ] **Configuration-driven experimentation** — Entire pipeline driven by a config file; experiments differ by config, not code
+- [ ] **Problem decomposition** — Actively considered; if applied, each sub-model independently validated
+
+If any principle is missing or weakly applied, go back and strengthen it before declaring the pipeline complete.

--- a/allora_research_model_skills/shared/feature-engineering.md
+++ b/allora_research_model_skills/shared/feature-engineering.md
@@ -1,0 +1,177 @@
+# Feature Engineering
+
+Features are the language your model uses to understand the world. Poorly designed features produce models that appear to work in backtesting but fail in production — usually because they encode future information, overfit to a specific time regime, or measure nothing meaningful. This document covers three principles that prevent these failure modes: physics-first design, horizon-adaptive parameterization, and lookahead prevention by construction.
+
+These principles apply regardless of your prediction target (returns, volatility, funding rates, sentiment scores) and regardless of your data sources (price data, on-chain metrics, social feeds, order book snapshots).
+
+## Physics-First Feature Design
+
+Every feature must answer a clear estimation question about the state of the system at time *t*. "What is the recent momentum?" is an estimation question. "Feature #47 from a blog post" is not. If you cannot articulate what physical or economic quantity a feature measures, remove it — the model cannot learn a meaningful relationship from noise dressed up as signal.
+
+### Estimation Goals as the Organizing Principle
+
+Group your features by what they estimate, not by how they are computed. A useful taxonomy for financial data:
+
+| Estimation Goal | What It Captures | Example Measurements |
+|---|---|---|
+| Trend | Directional persistence over a timescale | Returns over a window, slope of a moving average, rate of change |
+| Mean Reversion | Distance from a local equilibrium | Deviation from a rolling mean, z-score relative to recent history |
+| Volatility | Magnitude of recent fluctuations | Standard deviation of returns, range-based estimators, realized variance |
+| Microstructure | Short-lived supply/demand imbalance | Spread dynamics, order flow imbalance, trade arrival rate |
+| Cross-Asset | Relative behavior between instruments | Return differentials, correlation changes, basis spreads |
+| External Signal | Information from outside the price process | Sentiment scores, on-chain activity metrics, funding rates |
+
+This organization serves two purposes. First, it forces you to justify each feature's existence — if a feature doesn't map to an estimation goal, it probably doesn't belong. Second, it makes feature selection principled: you can reason about which estimation goals are relevant for your prediction target rather than performing blind search over hundreds of unnamed columns.
+
+### From Estimation Goal to Feature
+
+The path from an estimation goal to a concrete feature involves three decisions:
+
+1. **What to measure.** Choose the raw quantity that reflects your estimation goal. For a trend estimate, this might be a price return. For a volatility estimate, it might be squared returns or a high-low range.
+
+2. **Over what window.** Every measurement requires a lookback period. This is where horizon-adaptive parameterization (next section) becomes critical — do not pick arbitrary windows.
+
+3. **How to normalize.** Raw measurements vary enormously across assets and time regimes. Normalizing by recent volatility, by a rolling percentile rank, or by a z-score makes features comparable and helps the model generalize. A 2% daily return means something very different for a stablecoin versus a small-cap token.
+
+A well-designed feature makes all three decisions explicit and justifiable.
+
+### Extending to Non-Price Data
+
+The physics-first principle applies identically to alternative data sources. The data changes; the discipline does not.
+
+**Social sentiment data.** The estimation goal might be "crowd directional conviction" or "attention regime change." Measurements could include aggregated sentiment scores over a window, rate of change in post volume, or divergence between sentiment and recent price action. The same questions apply: what are you measuring, over what window, and how do you normalize across different activity levels?
+
+**On-chain metrics.** Estimation goals include "capital flow direction" (exchange inflows/outflows), "holder conviction" (wallet age distributions), or "network utilization pressure" (gas prices, transaction counts). Each produces features through the same three-decision framework.
+
+**Order book data.** Estimation goals might be "instantaneous supply/demand imbalance" or "depth resilience." The physics here is microstructure — features should measure quantities that have economic meaning at the timescale you operate on.
+
+The temptation with novel data sources is to throw raw columns at the model and hope it learns. Resist this. A raw sentiment score is not a feature — it is an ingredient. Transform it through the same estimation-goal framework: what does it measure, over what window, normalized how?
+
+## Horizon-Adaptive Parameterization
+
+Every feature involves a lookback window or period parameter. The most common mistake in feature engineering is hardcoding these: "use a 14-period RSI" or "compute 20-day volatility." These choices embed assumptions about the relevant timescale — assumptions that break when the prediction horizon changes.
+
+### The Core Idea
+
+All feature periods should be derived from a single parameter: the prediction horizon *h*. When *h* changes, every feature window auto-scales.
+
+A feature set spans multiple timescales relative to the horizon:
+
+- **Sub-horizon windows** capture recent dynamics: `h/4`, `h/2`. These see fine-grained structure within the prediction period.
+- **Horizon-scale windows** capture the regime the model is predicting over: `h`, `3h/2`. These match the natural timescale of the target.
+- **Super-horizon windows** capture the broader context: `2h`, `5h`, `10h`. These provide the slow-moving backdrop against which the horizon-scale dynamics play out.
+
+For example, if your prediction horizon is 24 one-hour bars:
+- Sub-horizon: 6-bar, 12-bar windows
+- Horizon-scale: 24-bar, 36-bar windows
+- Super-horizon: 48-bar, 120-bar, 240-bar windows
+
+If the horizon changes to 8 bars, every window scales automatically: 2, 4, 8, 12, 16, 40, 80. No manual retuning required.
+
+### Why This Matters
+
+Consider what happens without horizon-adaptive parameterization. You build a model for 24-hour prediction with features using 14-bar and 50-bar windows. These work well. Now you adapt the model to 4-hour prediction. The 14-bar and 50-bar windows now represent 14 hours and 50 hours — the 50-bar window is more than 12 times the prediction horizon. It is measuring structure that is almost entirely irrelevant to what happens in the next 4 hours, while the sub-horizon resolution is too coarse.
+
+The model might still "work" in backtesting because the optimizer can learn to ignore the irrelevant features. But you have wasted model capacity and introduced noise that hurts generalization.
+
+### Implementation Pattern
+
+Define your feature configuration as functions of the horizon, not as literal values:
+
+```
+Feature: rolling_trend
+  windows: [h/4, h/2, h, 2h, 5h]
+  measurement: return over window
+  normalization: divide by rolling volatility at window scale
+```
+
+When you change the horizon from `h=24` to `h=8`, the feature specification remains identical — only the derived window values change. This is the power of parameterization: your feature set is a *recipe*, not a list of numbers.
+
+### Edge Cases
+
+Some features have natural minimum windows below which they become meaningless (you cannot estimate a correlation from 2 observations). When `h/4` would produce a window shorter than the minimum meaningful lookback, clamp to the minimum. Document these minimums explicitly in your feature definitions.
+
+Similarly, some data sources have inherent timescales that override horizon scaling. Daily settlement events occur once per day regardless of your prediction horizon. Features measuring these events should be parameterized by the event frequency, not the prediction horizon. Use horizon-adaptive scaling for features where the relevant timescale is a modeling choice, and fixed scaling where the data physics dictates the timescale.
+
+## Lookahead Prevention by Construction
+
+Lookahead — using future information to predict the future — is the single most common cause of backtesting results that do not reproduce in production. It is also the hardest bug to find because it does not cause errors. The model trains, the metrics look good, often *suspiciously* good, and everything seems fine until live deployment.
+
+The solution is not "be careful." Developer discipline does not scale. Instead, build structural guardrails that make lookahead impossible by construction.
+
+### Principle: Make the Wrong Thing Impossible
+
+Every operation in your feature pipeline should be past-only by construction, not by convention. This means:
+
+1. **Rolling windows end at *t*, never extend past it.** A rolling mean computed at time *t* must use data from `[t-w, t]`, not `[t-w/2, t+w/2]` or any other window that includes future data. This seems obvious, but centering operations in standard libraries default to symmetric windows. Verify your rolling functions use a trailing window.
+
+2. **Target shift is applied once, globally, at the start of pipeline construction.** The target at time *t* is the value you want to predict, observed at time *t+h*. Compute `target[t] = f(raw_data[t+h])` once, early in your pipeline, and then build all features from the raw data at time *t*. This single shift is the *only* operation that touches future data. Everything downstream operates on past-only quantities.
+
+3. **Raw target columns are dropped from the model input.** After constructing the target, remove the raw future-looking column from the feature matrix. This prevents accidental leakage through transformations of the target that end up as features. If your feature matrix contains a column that has any temporal relationship to the target beyond what the model should learn, you have a leak.
+
+4. **Features computed from external data inherit the same discipline.** If you join an external dataset (sentiment scores, on-chain metrics) to your time index, verify the join uses as-of logic: for each timestamp *t*, use the most recent observation at or before *t*. Never use the closest observation regardless of direction — that introduces forward-looking information for half the joins.
+
+### Purged Cross-Validation
+
+Standard k-fold cross-validation allows information leakage at fold boundaries. If your training set contains data up to day 100 and your validation set starts at day 101, any feature with a lookback window longer than 1 day will have training-set information bleeding into validation-set features.
+
+Purged cross-validation inserts a gap buffer between training and validation folds. The gap should be at least as large as:
+- The prediction horizon *h* (to prevent target leakage)
+- The longest feature lookback window (to prevent feature leakage)
+
+In practice, use a gap of `max(h, max_feature_window)`. Observations within the gap are excluded from both training and validation. This wastes some data but guarantees temporal separation.
+
+For expanding-window or rolling-window validation (often more appropriate for financial data than k-fold), the gap principle still applies: insert a buffer between the end of the training window and the start of the evaluation window.
+
+### Feature Validation Checklist
+
+Before training any model, verify every feature passes these checks:
+
+**Temporal integrity:**
+- [ ] All rolling operations use trailing (past-only) windows
+- [ ] Target shift is computed exactly once and uses the correct horizon
+- [ ] No raw target or future-value columns remain in the feature matrix
+- [ ] External data joins use as-of (point-in-time) logic
+
+**Inference-time computability:**
+- [ ] Every feature can be computed using only data available at prediction time
+- [ ] No feature requires data that arrives with a delay longer than your prediction frequency
+- [ ] Features from external sources account for the source's publication lag
+
+**Stationarity and scaling:**
+- [ ] Features are normalized or transformed to be approximately stationary
+- [ ] Normalization parameters (rolling mean, rolling std) are computed from past data only
+- [ ] No feature has a trend component that would cause distribution shift over time
+
+**Implementation consistency:**
+- [ ] The feature computation code used in training is identical to the code used in inference
+- [ ] There is a single feature-engineering function called from both training and inference paths
+- [ ] No training-only preprocessing (e.g., global z-scoring across the full dataset) that cannot be replicated in real-time
+
+This last point deserves emphasis. A common pattern is to compute normalizing statistics (mean, standard deviation) across the entire training dataset and apply them to features. This is fine during training but impossible during inference — you do not have the future data needed to compute the global statistics. Use rolling normalizations computed from a trailing window, which are identical in both contexts.
+
+### Common Leakage Patterns
+
+These are the patterns that appear most often in practice. Each is subtle enough to pass code review and produce plausible-looking results.
+
+**Survivorship bias in universe construction.** If you construct your asset universe based on data availability at the end of the backtest period (e.g., "tokens that have 2 years of data"), you exclude assets that delisted or failed during the period. The remaining assets are the survivors, and your model learns to predict in a world that only contains winners. Construct your universe as-of each point in time.
+
+**Information in the index.** If your dataset's time index is filtered (e.g., only timestamps where trading occurred, or only timestamps where a certain condition holds), the filter itself may encode future information. A model can learn to exploit the fact that certain timestamps are present or absent. Use a regular time grid and handle missing data explicitly.
+
+**Leakage through feature selection.** If you select features based on their correlation with the target across the full dataset, you have used future information to choose your features. Feature selection must happen within the training fold only, re-evaluated at each cross-validation split.
+
+**Normalization across time.** Computing a z-score using the mean and standard deviation of the entire time series (including future observations) leaks future information into every feature value. Always normalize using trailing windows.
+
+## Putting It Together
+
+The three principles reinforce each other:
+
+1. **Physics-first design** ensures every feature measures something meaningful, reducing the search space and making the model's behavior interpretable.
+
+2. **Horizon-adaptive parameterization** ensures the feature set automatically adjusts to the prediction timescale, eliminating a major source of manual tuning and cross-horizon inconsistency.
+
+3. **Lookahead prevention** ensures the features your model sees during training are identical to what it will see during inference, closing the gap between backtest performance and live performance.
+
+When you add a new data source or extend to a new prediction target, apply all three: define the estimation goals the new data serves, parameterize its lookback windows relative to the horizon, and verify every operation is past-only. The discipline is the same regardless of what you are building.
+
+For how these features integrate into the broader model development workflow — including validation, loss design, and deployment — see the [methodology overview](methodology.md) and [validation framework](validation-framework.md).

--- a/allora_research_model_skills/shared/loss-design.md
+++ b/allora_research_model_skills/shared/loss-design.md
@@ -1,0 +1,390 @@
+# Loss Design
+
+The loss function is the only thing your model directly optimizes. Every other metric — directional accuracy, Sharpe ratio, profit factor — is a downstream consequence of what the loss rewards and penalizes. Choosing MSE because it is the default is like choosing a car's steering by ignoring it: you will end up somewhere, but probably not where you intended.
+
+This document treats loss design as a first-class modeling decision. We cover the design dimensions, walk through CZAR (Composite Zero-Agnostic Returns) loss as a concrete example for log-returns prediction, then generalize to other prediction targets.
+
+## Loss as a Modeling Decision
+
+A loss function encodes your beliefs about what constitutes a good prediction. These beliefs include:
+
+- **What errors matter most.** Is predicting the wrong direction worse than being off by a constant magnitude? Should large errors be penalized quadratically (MSE), linearly (MAE), or according to some other schedule?
+
+- **What context qualifies an error.** A 1% prediction error during a calm market may be unacceptable, while a 5% error during a volatility spike may be reasonable. Should the loss normalize errors by local conditions?
+
+- **What the prediction will be used for.** If the prediction drives a trading decision, directional accuracy matters more than point-estimate precision. If it drives a risk model, underestimating tail events is far worse than overestimating them.
+
+Standard losses (MSE, MAE, Huber) encode none of these beliefs. They treat all errors as symmetric, context-free, and equally important regardless of direction. For many financial prediction tasks, this is the wrong set of assumptions.
+
+## Design Dimensions
+
+When designing a custom loss for financial prediction, consider these three dimensions. They are independent — you can combine them freely.
+
+### Directional Asymmetry
+
+For predictions that drive trading decisions, the direction of the error is often more important than its magnitude. Predicting +2% when the actual move is -1% (wrong direction by 3 percentage points) is worse than predicting +2% when the actual move is +5% (right direction, off by 3 percentage points).
+
+A directionally-asymmetric loss applies a higher penalty when the predicted and actual values have opposite signs. The simplest approach multiplies the base loss by a scaling factor when the prediction and target disagree on sign:
+
+```
+loss_i = base_loss(pred_i, target_i) * (1 + alpha * wrong_direction_i)
+```
+
+where `wrong_direction_i = 1` when `sign(pred_i) != sign(target_i)` and `0` otherwise. The parameter `alpha` controls how much more the model is penalized for directional errors. Setting `alpha = 0` recovers the symmetric base loss.
+
+The difficulty is gradient behavior at the sign boundary. A hard sign function has zero gradient, which means the optimizer receives no signal about *how close* a prediction was to the correct direction. Smooth approximations (e.g., `tanh(pred * target * scale)`) provide gradient flow through the transition, which helps the optimizer learn the boundary.
+
+### Volatility Normalization
+
+Financial return magnitudes vary enormously across time — a 1% daily return might be a 0.5-sigma event in a calm market or a 0.1-sigma event during a crisis. If the loss treats all 1% errors equally, the model will be dominated by high-volatility periods in the training data, because those periods produce the largest raw errors.
+
+Normalizing the loss by local volatility puts all time periods on an equal footing:
+
+```
+normalized_error_i = (pred_i - target_i) / local_vol_i
+```
+
+where `local_vol_i` is a trailing estimate of volatility at time *i* (e.g., rolling standard deviation of returns over a recent window). This means the model optimizes for *risk-adjusted* prediction quality rather than raw magnitude.
+
+The choice of volatility estimator and its lookback window matters. Use the same horizon-adaptive parameterization discussed in the [feature engineering](feature-engineering.md) guide: the volatility normalization window should scale with the prediction horizon.
+
+A practical consideration: ensure `local_vol_i` has a floor (minimum value) to prevent division-by-zero in extremely quiet markets. This floor should be small enough to be reached only in degenerate cases.
+
+### Near-Zero Awareness
+
+For return-based prediction targets, there is a regime where directional asymmetry becomes counterproductive: near-zero returns. When the actual return is essentially zero (below the market's noise floor), the "direction" is meaningless — it is determined by microstructure noise, not by any predictable process.
+
+Penalizing the model for getting the "wrong" direction on a +0.001% return teaches the model to fit noise. A well-designed loss should recognize that near-zero returns carry no directional information and reduce or eliminate the directional penalty in this regime.
+
+This can be implemented through a continuous weighting function that transitions from "direction matters" (far from zero) to "direction is noise" (near zero). The transition scale should reflect the market's noise floor — itself a function of volatility.
+
+## CZAR Loss: A Concrete Example for Log-Returns
+
+CZAR (Composite Zero-Agnostic Returns) loss is a purpose-built loss function for log-returns prediction that combines all three design dimensions into a single piecewise objective built on the Cauchy (Lorentzian) kernel.
+
+### Motivation
+
+Log-returns have specific properties that standard losses handle poorly:
+
+1. **Direction matters economically.** The sign of a log-return maps directly to a trading decision (long vs. short). A wrong-sign prediction is categorically worse than an imprecise same-sign prediction. MSE treats them equivalently.
+
+2. **The zero-return problem.** A large fraction of short-horizon returns are effectively zero — they fall within the bid-ask spread or are indistinguishable from microstructure noise. A model that tries to predict the direction of these returns is fitting noise.
+
+3. **Volatility clustering.** The magnitude of log-returns varies by orders of magnitude across market regimes. A loss that weights all observations equally will be dominated by extreme periods.
+
+### Design Overview
+
+**Volatility normalization.** All inputs are z-scored before loss computation: `z = (y - mean) / std`, where `std` is the local rolling standard deviation and `mean` is the local mean (typically zero for short horizons). This makes the loss regime-invariant.
+
+**Core kernel.** The loss is built on the Cauchy derivative `f(x) = 1 / (1 + x²)` and its antiderivative `arctan(x)`. Bounded gradients give robustness to outliers with smooth transitions. The `alpha ∈ [0, 1]` parameter controls MSE-like curvature at the origin via a horizontal shift `δ = alpha / √3`.
+
+**Three-region piecewise structure.** Let `s = sign(z_true)` and `u = s · z_pred`. The loss partitions based on sign agreement and magnitude:
+- **Region 1 (`u ≤ 0`) — Wrong sign.** Steepest penalty. Quadratic + linear directional term.
+- **Region 2 (`0 < u ≤ |z_true|`) — Right sign, undershoot.** Arctan transition with decreasing gradient as prediction approaches truth.
+- **Region 3 (`u > |z_true|`) — Right sign, overshoot.** Quadratic in overshoot, with curvature that decreases for large `|z_true|`.
+
+**Zero-agnostic softening.** The `epsilon` parameter (in std units) smoothly reduces loss as `|z_true| → 0`, preventing the model from fitting noise in near-zero returns. The `tau` parameter controls transition smoothness via a softplus hinge.
+
+### Parameters
+
+| Parameter | Role | Typical range |
+|-----------|------|---------------|
+| `std` | Local volatility for z-scoring | Rolling std of returns over a horizon-adaptive window |
+| `mean` | Local mean for centering | Rolling mean, or 0 for short horizons |
+| `alpha` | MSE curvature at origin | `[0, 1]`. 0 = linear only, 1 = maximum curvature |
+| `epsilon` | Zero-agnostic scale (in std units) | ~1. Returns within ~epsilon standard deviations of zero are softened |
+| `tau` | Hinge smoothness for zero-agnostic transition | ~0.05. Smaller = sharper transition |
+
+### Reference Implementation
+
+The full implementation below includes the loss function, analytical gradient, and analytical Hessian. The gradient and Hessian are essential for use as a custom objective in gradient boosting frameworks (LightGBM, XGBoost). Note the use of pseudo-gradients and pseudo-Hessians in some regions for numerical stability.
+
+```python
+import numpy as np
+
+
+def derivative(x):
+    return 1.0 / (1.0 + x**2)
+
+
+def antiderivative(x):
+    return np.arctan(x)
+
+
+def double_derivative(x):
+    return 2.0 * np.abs(x) / (1.0 + x**2)**2
+
+
+def eps_effective(eps, delta):
+    # Rescale epsilon so that 1 - loss(z_true, 0) / loss(0, epsilon) crosses zero at epsilon
+    if abs(delta) == 0:
+        return np.arctan(eps)
+
+    A = (1 + delta**2) * (antiderivative(eps + delta) - antiderivative(delta))
+    beta = delta / (1 + delta**2)  # coefficient on eps_eff^2 in loss(0, eps_eff, 1)
+
+    # Solve beta*x^2 + x - A = 0 for positive x
+    return (-1 + np.sqrt(1 + 4 * beta * A)) / (2 * beta)
+
+
+def softplus(x):
+    return np.maximum(x, 0.0) + np.log1p(np.exp(-np.abs(x)))
+
+
+def norm_smooth(z_true, eps, delta, tau):
+    # Minimum value of the normalisation at z_true, set by the limit that loss(z_true,0)
+    # does not decrease as z_true increases.
+    # Simplified from: 1 - loss(z_true, 0) / loss(0, epsilon)
+    a = np.abs(z_true)
+    d2p1 = delta**2 + 1
+    num = d2p1 * (antiderivative(a + delta) - antiderivative(delta))
+    denom = eps + delta / d2p1 * eps**2
+    norm_min = 1.0 - num / denom
+
+    if tau <= 0:
+        # Hard transition
+        return np.maximum(norm_min, 0.0)
+
+    # Smooth transition when norm drops below zero
+    # Scale tau_eff by |norm_inf| so the asymptote is invariant across eps, delta
+    # Asymptotic value of norm_min as |z_true| -> inf
+    num_inf  = d2p1 * (0.5*np.pi - antiderivative(delta))
+    norm_inf = 1.0 - num_inf / denom
+    tau_eff = np.abs(tau) * np.abs(norm_inf)
+    return softplus(norm_min / tau_eff) / softplus(1 / tau_eff)
+
+
+def czar_loss(y_true, y_pred, std, mean=0, alpha=1, epsilon=1, tau=0.05):
+    """
+    Composite Zero-Agnostic Return Loss
+
+    Asymmetric, piecewise function that is
+        * Linear (alpha=0) or quadratic (alpha>0) when y_pred has opposite sign to y_true
+        * Linear (alpha=0) or quadratic (alpha>0) when |y_pred| > |y_true|, with a decreasing
+          gradient as |z_true| increases
+        * Arctangent transition from 0 < |y_pred| < |y_true|
+
+    Args:
+        y_true: True returns
+        y_pred: Predicted returns
+        std: Standard deviation of true returns
+        mean: Mean of true returns
+        alpha: MSE term constant (alpha=0 is linear only, alpha=1 is maximum gradient)
+        epsilon: Loss softening scale, in units of standard deviation. Optimum is eps~1
+        tau: Scaling for softening hinge function
+    Returns:
+        Value of loss
+    """
+
+    if alpha < 0 or alpha > 1:
+        raise ValueError(f'alpha must be between 0 and 1, got {alpha}')
+
+    z_true = (y_true - mean) / std
+    z_pred = (y_pred - mean) / std
+
+    s = np.where(z_true == 0, 1, np.sign(z_true))
+    s_pred = np.where(z_pred == 0, 1, np.sign(z_pred))
+    a = np.abs(z_true)
+    u = s * z_pred
+
+    # Apply horizontal shift to function for smooth change in gradient
+    # Alpha should be between 0 and 1. 1/sqrt(3) shifts to the peak of the hessian function
+    delta = alpha / np.sqrt(3)
+    d2p1 = delta**2 + 1
+
+    d_true = z_true + s * delta
+    d_pred = z_pred + s_pred * delta
+
+    h1 = d2p1 * double_derivative(delta)
+    h3 = d2p1 * double_derivative(d_true)
+
+    # Region 1: opposite sign (u <= 0): grad = -s + MSE term
+    # Constant so that the middle branch hits zero at z_pred = z_obs
+    C = s * d2p1 * (antiderivative(d_true) - antiderivative(s * delta))
+    L1 = 0.5 * h1 * z_pred**2 - s * z_pred + C
+
+    # Region 2: same sign, before threshold (0 < u <= a): grad = -s * antiderivative(z_pred)
+    # antiderivative(d_true) term so that the middle branch hits zero at z_pred = z_obs
+    L2 = s * d2p1 * (antiderivative(d_true) - antiderivative(d_pred))
+
+    # Region 3: past threshold (u > a): grad = s * derivative(z_obs) + MSE term
+    dz = z_pred - z_true
+    L3 = 0.5 * np.minimum(h3, h1) * dz**2 + s * d2p1 * derivative(d_true) * dz
+
+    # Softening term
+    if epsilon > 0:
+        eps_eff = eps_effective(epsilon, delta)
+        softening_0 = czar_loss(0, eps_eff, 1., epsilon=0, alpha=alpha)
+        norm = norm_smooth(z_true, eps_eff, delta, tau)
+        Lsoft = norm * softening_0
+    else:
+        Lsoft = 0
+
+    return np.where(u <= 0, L1, np.where(u <= a, L2, L3)) + Lsoft
+
+
+def czar_gradient(y_true, y_pred, std, mean=0, alpha=1):
+    z_true = (y_true - mean) / std
+    z_pred = (y_pred - mean) / std
+
+    s = np.where(z_true == 0, 1, np.sign(z_true))
+    s_pred = np.where(z_pred == 0, 1, np.sign(z_pred))
+    a = np.abs(z_true)
+    u = s * z_pred
+
+    delta = alpha / np.sqrt(3)
+    d2p1 = delta**2 + 1
+
+    d_true = z_true + s * delta
+    d_pred = z_pred + s_pred * delta
+
+    h1 = d2p1 * double_derivative(delta)
+    h3 = d2p1 * double_derivative(d_true)
+
+    # Region 1: opposite sign (u <= 0)
+    # Pseudo gradient for numerical stability:
+    G1 = h1 * z_pred - np.sign(z_true)
+
+    # Region 2: same sign, before threshold (0 < u <= a)
+    G2 = -s * d2p1 * derivative(d_pred)
+
+    # Region 3: past threshold (u > a)
+    # Pseudo gradient for numerical stability:
+    G3 = np.minimum(h3, h1) * (z_pred - z_true)
+
+    return np.where(u <= 0, G1, np.where(u <= a, G2, G3)) / std
+
+
+def czar_hessian(y_true, y_pred, std, mean=0, alpha=1):
+    z_true = (y_true - mean) / std
+    z_pred = (y_pred - mean) / std
+
+    s = np.where(z_true == 0, 1.0, np.sign(z_true))
+    s_pred = np.where(z_pred == 0, 1.0, np.sign(z_pred))
+    a = np.abs(z_true)
+    u = s * z_pred
+
+    delta = alpha / np.sqrt(3)
+    d2p1 = delta**2 + 1
+
+    d_true = s * (np.abs(z_true) + delta)
+    d_pred = s_pred * (np.abs(z_pred) + delta)
+
+    # Region 1: opposite sign (u <= 0)
+    h1 = d2p1 * double_derivative(delta)
+    H1 = np.full_like(d_pred, h1)
+
+    # Region 2: same sign, before threshold (0 < u <= a)
+    # Pseudo hessian for numerical stability:
+    H2 = (1.0 + d_pred**2) * double_derivative(d_pred)
+
+    # Region 3: past threshold (u > a)
+    # Consistent with H2 pseudo hessian:
+    h3 = (1.0 + d_true**2) * double_derivative(d_true)
+    H3 = np.full_like(d_pred, np.minimum(h1, h3))
+
+    return np.where(u <= 0, H1, np.where(u <= a, H2, H3)) / std**2
+```
+
+### Why This Works for Log-Returns Specifically
+
+CZAR is designed for log-returns and should not be blindly applied to other prediction targets. The reasons it works here are specific to the problem:
+
+- Log-returns are naturally centered around zero, making the three-region sign-based partitioning well-defined.
+- The direction of a log-return directly maps to a trading decision (long vs. short), making the directional asymmetry (Region 1 penalty) economically meaningful.
+- Volatility normalization of log-returns produces approximately standard-normal residuals, so `epsilon ≈ 1` has a natural interpretation as "within one standard deviation of zero."
+- The Cauchy kernel's bounded gradients provide robustness to the fat-tailed distribution of z-scored returns.
+
+For other prediction targets, the design principles transfer but the specific mechanism does not. See the next section for guidance on adapting loss design to different targets.
+
+## Loss Design for Other Prediction Targets
+
+The three design dimensions (directional asymmetry, volatility normalization, near-zero awareness) are general, but their application depends on the prediction target's properties.
+
+### Volatility Prediction
+
+When predicting future volatility (realized variance, conditional standard deviation), the error structure is inherently asymmetric:
+
+- **Underestimating volatility is more dangerous than overestimating it.** Underestimation leads to undersized hedges and unexpected losses. Overestimation leads to conservative positioning — suboptimal but not catastrophic.
+
+- **Volatility has a positive floor.** Unlike returns, volatility cannot be negative and is rarely near zero. The near-zero awareness dimension is less relevant.
+
+- **Volatility is right-skewed.** Large volatility spikes are common; a loss that penalizes overestimation and underestimation equally will underfit the right tail.
+
+A volatility-specific loss might apply an asymmetric penalty: standard loss when overpredicting, scaled-up loss when underpredicting. The scaling factor encodes your risk preference — how much worse is underestimation than overestimation?
+
+### Funding Rate Prediction
+
+Funding rates have distinctive properties:
+
+- **Sign changes are critical events.** A funding rate that crosses zero signals a shift from one side of the market paying the other. Capturing these transitions is often more valuable than precise magnitude estimation.
+
+- **Persistent regimes.** Funding rates tend to stay positive or negative for extended periods, then abruptly flip. A loss that emphasizes sign-change detection might weight observations near the zero crossing more heavily.
+
+- **Bounded magnitude.** Most funding rates operate within known bounds (set by exchange rules). The tail behavior differs from returns — extreme values are clamped, not fat-tailed.
+
+A funding-rate loss might combine a base magnitude loss with a transition-sensitive component that increases the penalty for predictions that miss a sign change while reducing the penalty for magnitude errors during stable-sign periods.
+
+### Sentiment or Categorical Scores
+
+When the prediction target is ordinal (bullish/neutral/bearish) or bounded (a sentiment score on [0, 1]):
+
+- Standard classification losses (cross-entropy) may apply directly for ordinal targets.
+- For bounded continuous scores, the loss should respect the bounds — predictions near the boundaries should not be penalized for clipping.
+- If the score drives a trading decision, the relevant question is not "how accurate is the score?" but "how reliably does a threshold crossing predict a regime change?"
+
+## Loss and Evaluation: Aligned but Distinct
+
+The loss function is what the optimizer sees during training. Evaluation metrics are what you use to decide if the model is good. These should be aligned in spirit but are not identical, and conflating them causes subtle problems.
+
+### Why They Differ
+
+**The loss must be differentiable.** Evaluation metrics do not. You might care about the percentage of correct directional predictions (accuracy), but accuracy has zero gradient almost everywhere. The loss needs a smooth surrogate that pushes the model toward higher accuracy while remaining optimizable.
+
+**The loss operates per-sample.** Evaluation metrics often aggregate across the full validation set. Sharpe ratio, for example, is a portfolio-level metric that depends on the joint distribution of predictions. You cannot decompose it into independent per-sample contributions for gradient computation.
+
+**The loss is trained on; evaluation is measured on.** If you use the same metric for both, and that metric has any exploitable structure, the optimizer will find a degenerate solution that scores well on the metric without producing useful predictions. Keep the training loss and the evaluation metrics related but not identical.
+
+### The Alignment Principle
+
+A well-designed loss should produce models that score well on your evaluation metrics, even though the metrics are not what the model directly optimizes. If you find that your loss is decreasing during training but your evaluation metrics are not improving (or are getting worse), the loss and evaluation are misaligned — the loss is rewarding something the evaluation does not value.
+
+When this happens, the fix is usually in the loss, not the evaluation. The evaluation metrics capture what you actually care about. The loss is your imperfect attempt to make that objective differentiable and per-sample decomposable. Iterate on the loss design until alignment improves.
+
+## Custom Loss Implementation
+
+Designing a good loss is worthless if the implementation is numerically broken. These considerations apply to any custom loss:
+
+### Gradient Availability
+
+Automatic differentiation handles most cases, but verify:
+
+- **Non-differentiable operations.** Hard sign functions, argmax, and indicator functions have zero or undefined gradients. Use smooth approximations: `tanh(x * scale)` instead of `sign(x)`, soft-threshold functions instead of hard thresholds.
+- **Conditional branches.** If your loss has `if/else` branches based on the prediction or target values, ensure gradients flow through all branches. Some frameworks handle this automatically; others may silently return zero gradients for inactive branches.
+- **Gradient magnitude.** Custom losses can produce gradients that are orders of magnitude larger or smaller than standard losses. This interacts with learning rate selection. Scale your loss so that its gradients are in a reasonable range, or adjust the learning rate accordingly.
+
+### Numerical Stability
+
+- **Division by near-zero values.** Volatility normalization requires dividing by a volatility estimate. Add a floor: `max(vol, epsilon)` where `epsilon` is small but not negligible (e.g., 1e-8).
+- **Log of near-zero values.** If your loss involves logarithms, guard against `log(0)` with a similar floor.
+- **Large exponents.** Exponential weighting can produce Inf or NaN. Use clamped exponents or log-sum-exp formulations for numerical safety.
+- **Mixed precision.** If training in half precision (float16), the reduced dynamic range makes numerical issues more likely. Test your custom loss in the precision you will actually train in.
+
+### Batch Behavior
+
+- **Per-sample decomposition.** Most training frameworks expect the loss to decompose as a mean (or sum) over the batch. If your loss has inter-sample dependencies (e.g., a ranking component), handle batch aggregation explicitly.
+- **Batch size sensitivity.** Volatility normalization computed per-batch rather than per-sample can introduce batch-size-dependent behavior. Prefer pre-computed volatility normalization (computed during feature engineering and stored as a column) over within-loss computation.
+- **NaN propagation.** A single NaN in the batch can poison the entire batch loss. Guard against NaN-producing edge cases (division by zero, log of negative values) at the sample level, not the batch level.
+
+## Summary
+
+Loss design is a chain of deliberate decisions:
+
+1. **Start from your use case.** What does a "good prediction" mean for your downstream application? What errors are catastrophic versus tolerable?
+2. **Choose your design dimensions.** Directional asymmetry, volatility normalization, and near-zero awareness are the three main levers. Not all apply to every problem.
+3. **Implement carefully.** Gradient availability, numerical stability, and batch behavior are implementation concerns that can silently break a well-designed loss.
+4. **Validate alignment.** Monitor both the training loss and your evaluation metrics. If they diverge, iterate on the loss design.
+
+For log-returns prediction, CZAR provides a principled starting point that addresses the specific challenges of that target. For other targets, use the design dimensions as a framework to reason about what your loss should reward and penalize — then build accordingly.
+
+For how loss design integrates with the broader model development workflow, see the [methodology overview](methodology.md) and [validation framework](validation-framework.md).

--- a/allora_research_model_skills/shared/methodology.md
+++ b/allora_research_model_skills/shared/methodology.md
@@ -1,0 +1,221 @@
+# Nine Principles for Robust Financial Prediction
+
+This document describes a methodology for building financial prediction models that survive contact with real markets. Each principle exists because a specific failure mode is common, costly, and preventable. Together, they form a complete framework — not a checklist of nice-to-haves, but a set of interlocking constraints that prevent the most damaging mistakes in quantitative model development.
+
+The methodology is prediction-target agnostic. Whether you are forecasting returns, volatility, funding rates, spreads, sentiment, or any other quantity, these principles apply. The examples are generic by design.
+
+---
+
+## Principle 1: Physics-First Feature Engineering
+
+**Failure mode prevented:** Feature soup — hundreds of technical indicators thrown at a model with no rationale, producing fragile correlations that collapse out of sample.
+
+Every feature in your model should answer a clear question: *what economic or physical quantity does this feature estimate?* This is what we mean by an "estimation goal." A moving average ratio is not just a number — it estimates short-term momentum relative to a longer-term trend. A volatility measure estimates the dispersion of returns over a specific horizon. A volume imbalance estimates buying/selling pressure.
+
+When you organize features around estimation goals, three things happen:
+
+1. **Feature sets become interpretable.** You can explain why each feature is in the model and what information it contributes. This is not a luxury — it is how you diagnose model failures. When a model degrades, you need to know which estimation goals are no longer predictive.
+
+2. **Redundancy becomes visible.** If three features all estimate the same quantity (e.g., short-term momentum), you know you have redundancy. This is fine if intentional (ensemble of estimators), but dangerous if accidental (inflated feature importance, multicollinearity).
+
+3. **Feature engineering becomes systematic.** Instead of searching a library of 200 indicators, you ask: *what quantities might be predictive of my target?* Then you construct features that estimate those quantities. The search space shrinks from "all possible indicators" to "features that estimate identified estimation goals."
+
+This principle generalizes beyond price and volume data. Social sentiment features estimate crowd belief. On-chain features estimate network activity or capital flows. Alternative data features estimate real-world economic quantities. The key is always the same: every feature must have a stated estimation goal that connects it to the prediction target through a causal or structural argument.
+
+**Composition with other principles:** Estimation goals determine what to measure. Principle 2 (horizon-adaptive parameterization) determines at what scale to measure it. Principle 3 (lookahead prevention) ensures you measure it using only information available at prediction time.
+
+---
+
+## Principle 2: Horizon-Adaptive Parameterization
+
+**Failure mode prevented:** Scale mismatch — features tuned to one prediction horizon break when the horizon changes, or features at wildly different timescales create incoherent inputs.
+
+Every temporal parameter in your feature pipeline — lookback windows, smoothing periods, decay rates — should be derived from the prediction horizon. Define your horizon as `H` (in whatever time units your data uses), then express all feature periods as fractions or multiples of `H`.
+
+For example, if you have a "short-term momentum" estimation goal, its lookback might be `0.5 * H`. A "medium-term trend" might use `2 * H`. A "long-term regime" might use `10 * H`. The exact multipliers are modeling choices that encode your beliefs about which timescales carry predictive information for your target.
+
+This has two critical benefits:
+
+1. **Horizon portability.** When you change the prediction horizon (say, from 1-hour to 4-hour), all feature periods scale automatically. You do not need to re-tune dozens of hardcoded lookback windows. The structural relationships between features are preserved.
+
+2. **Coherent scale coverage.** By expressing everything relative to `H`, you ensure your features span a coherent range of timescales around the prediction horizon. You will not accidentally include a 200-day moving average when predicting 5-minute returns — the mismatch becomes obvious when you see a multiplier of 57,600.
+
+The multipliers themselves are hyperparameters, but they are *meaningful* hyperparameters. A short-term lookback of `0.25 * H` versus `0.75 * H` encodes a belief about how quickly short-term dynamics evolve relative to your prediction window. This is searchable and interpretable — unlike raw period values that carry no inherent meaning.
+
+**Composition with other principles:** Horizon-adaptive periods feed into lookahead prevention (Principle 3) because gap buffer sizing in cross-validation should also be derived from `H`. Configuration-driven experimentation (Principle 8) makes the multipliers searchable parameters in your experiment config.
+
+---
+
+## Principle 3: Lookahead Prevention by Architecture
+
+**Failure mode prevented:** Data leakage — future information bleeding into training data, producing models that appear excellent in backtests and fail immediately in production.
+
+Lookahead is the single most dangerous failure mode in financial prediction. It is also the most insidious, because it produces models that look great on every metric. The model is not learning to predict — it is learning to read the answer sheet.
+
+Developer discipline is not sufficient protection. "I will be careful" does not scale. You need structural guardrails that make lookahead architecturally impossible:
+
+1. **Past-only computation.** Every feature function must be computed using only data up to and including the current timestamp. This means expanding-window or rolling-window computations — never operations that implicitly use future data (like pandas `pct_change()` without careful shift management, or normalization using full-sample statistics).
+
+2. **Global target shift.** The target variable (what you are predicting) should be shifted once, in one place, with the shift amount derived from the prediction horizon. This single point of truth prevents inconsistencies between how features and targets are aligned.
+
+3. **Raw column exclusion.** After feature computation, drop all raw data columns (prices, volumes, raw alternative data) from the model input. Only computed features should enter the model. Raw columns are dangerous because they can leak absolute level information or future-adjacent values.
+
+4. **Purged cross-validation with gap buffers.** Standard k-fold cross-validation is invalid for time series because neighboring samples share information. Purged walk-forward cross-validation removes samples near the train/test boundary, and a gap buffer (sized relative to the prediction horizon) ensures no temporal leakage between folds. The gap should be at least as large as the prediction horizon, and often larger if features use long lookback windows.
+
+Each guardrail addresses a different leakage vector. Together, they create defense in depth. If one layer has a subtle bug, the others still provide protection.
+
+**How to audit for lookahead:** A useful diagnostic is to train a model where the target is shifted by a very large amount (e.g., predict returns 1 year ahead using the same features). If the model still appears highly accurate, you have leakage — real predictive signal decays with horizon, but leaked signal does not.
+
+**Composition with other principles:** Lookahead prevention interacts with every other principle. Feature engineering (Principle 1) must respect past-only constraints. Horizon-adaptive periods (Principle 2) determine gap buffer sizing. Three-stage separation (Principle 4) adds temporal partitioning on top of purged CV. Validation (Principle 6) should include checks that detect residual leakage.
+
+---
+
+## Principle 4: Three-Stage Separation
+
+**Failure mode prevented:** Double-dipping — using the same data to both select and evaluate a model, producing overconfident performance estimates that do not generalize.
+
+Model development has three distinct stages, each with a specific purpose and strict data boundaries:
+
+**Stage 1: Inner optimization (hyperparameter selection).** This is where you search for the best model configuration. Use purged walk-forward cross-validation on your training data. The inner CV score guides your optimizer (grid search, Bayesian optimization, etc.) toward good hyperparameters. This stage consumes data — the signal it extracts is "baked into" the selected hyperparameters.
+
+**Stage 2: Outer evaluation (honest assessment).** After selecting hyperparameters, evaluate the chosen configuration on time windows that were never seen during Stage 1 — not even indirectly through hyperparameter selection. Fix all hyperparameters and retrain the model on each evaluation window's training portion, then test on its held-out portion. The outer evaluation score is your honest estimate of out-of-sample performance.
+
+**Stage 3: Production deployment (full-data retrain).** Once a model passes outer evaluation, retrain it on all available data using the selected hyperparameters and deploy it. This maximizes the information available to the deployed model.
+
+The critical boundary is between Stage 1 and Stage 2. It is tempting to "just add one more optimization" after seeing outer evaluation results — but every such adjustment converts Stage 2 into another round of Stage 1. The outer evaluation windows must be inviolate. If you want to iterate, go back to Stage 1 with different search configurations and re-evaluate.
+
+Many practitioners skip Stage 2 entirely, using inner CV scores as their performance estimate. This is dangerous because inner CV scores are optimistically biased — the optimizer has selected the configuration that performs best on those specific folds. Outer evaluation on truly independent windows corrects this bias.
+
+**Composition with other principles:** Three-stage separation provides the temporal framework. Purged CV (Principle 3) operates within Stage 1. Multi-threshold validation (Principle 6) defines the quality gates for Stage 2. Optimizer-gaming prevention (Principle 7) ensures the Stage 1 / Stage 2 boundary is not compromised by validation set sizing choices.
+
+---
+
+## Principle 5: Loss Function as a Modeling Decision
+
+**Failure mode prevented:** Default-loss blindness — using MSE or MAE by habit, missing the opportunity to encode domain knowledge directly into the training objective.
+
+The loss function is not a technical afterthought — it is one of the most consequential modeling decisions you make. It defines what "good" means to your model. A model trained on MSE will produce predictions that minimize squared error, which may or may not align with what you actually care about.
+
+Consider what beliefs you have about your prediction problem:
+
+- **Directional importance.** If you care more about getting the direction right than the magnitude, your loss should penalize directional errors more heavily than magnitude errors. Standard regression losses treat overshooting and undershooting symmetrically — but in many financial applications, predicting +1% when the actual is -1% is far worse than predicting +1% when the actual is +3%.
+
+- **Volatility normalization.** If your target exhibits heteroscedastic behavior (variable volatility over time), a raw prediction error of 1% means very different things in calm versus turbulent markets. A loss that normalizes by local volatility can produce better-calibrated predictions across regimes.
+
+- **Regime awareness.** Markets alternate between different behavioral regimes. A loss function that weights recent observations more heavily can help the model adapt to regime changes, at the cost of slower learning from distant history.
+
+- **Tail behavior.** If large errors are disproportionately costly (or important), the loss should reflect this. Squared-error losses already penalize large errors more, but you might need even stronger tail sensitivity — or conversely, you might want robustness to outliers via a loss that saturates for extreme errors.
+
+In the specific context of log-returns prediction, the CZAR (Composite Zero-Agnostic Returns) loss illustrates how multiple beliefs can be composed into a single objective. CZAR is a piecewise loss built on the Cauchy kernel that z-scores inputs by local volatility, applies steep penalties for wrong-sign predictions (directional asymmetry), uses a bounded arctan transition for same-sign predictions (outlier robustness), and smoothly reduces loss near zero returns where direction is unreliable (zero-agnostic softening). See [loss design](./loss-design.md) for the full mathematical structure. This is not the only valid loss design — it is an example of principled loss construction where each component addresses a specific belief about the problem.
+
+The key insight is that loss design is a *modeling* activity. It belongs in the same conversation as feature selection and architecture choice, not in a "training details" appendix.
+
+**Composition with other principles:** The loss should be coherent with your feature engineering (Principle 1) — if your features estimate momentum but your loss penalizes magnitude error, there is a mismatch. Loss design interacts with problem decomposition (Principle 9) because different sub-problems may warrant different loss functions. Multi-threshold validation (Principle 6) should include metrics that are independent of the training loss to catch cases where loss optimization does not translate to decision quality.
+
+---
+
+## Principle 6: Multi-Threshold Signal Validation
+
+**Failure mode prevented:** Single-metric flattery — a model that scores well on one metric while failing on others, producing an illusion of quality that collapses in deployment.
+
+No single metric can fully characterize a prediction model's quality. A model with 55% directional accuracy might achieve it through a few lucky large bets or through consistent small-edge predictions — these have very different risk profiles. A model with low mean error might systematically overpredict in one regime and underpredict in another, averaging out to look good.
+
+Multi-threshold validation requires that a model simultaneously pass several independent quality gates before it is deemed acceptable:
+
+- **Directional accuracy.** Does the model predict the correct sign (direction) of the target more often than chance? This is the most basic test of predictive value.
+
+- **Statistical significance.** Is the directional accuracy statistically distinguishable from random guessing? Use binomial tests or similar — a model with 51% accuracy on 100 predictions is not meaningfully different from a coin flip, even though 51% > 50%.
+
+- **Calibration.** Are the model's confidence levels (prediction magnitudes) well-calibrated? A model that predicts large moves should see larger actual moves. Poor calibration means the model's predictions carry misleading magnitude information.
+
+- **Financial improvement.** Does the model produce better financial outcomes (however you define them for your application) than a simple baseline? This is the ultimate test — statistical significance means nothing if the model does not improve decisions.
+
+The simultaneous requirement is critical. A model must pass *all* gates, not just some. This creates a robust filter that catches models that are "good" on one dimension but deficient on others.
+
+**How to set thresholds:** Thresholds should be informed by your application requirements, not by what your current model achieves. Start with what minimum performance would make the model useful in practice, then verify whether your model meets that bar. Adjusting thresholds to match current model performance is circular reasoning.
+
+**Composition with other principles:** Multi-threshold validation is the quality gate mechanism for Stage 2 (outer evaluation) of three-stage separation (Principle 4). The specific metrics you choose should relate to your estimation goals (Principle 1) and your loss function (Principle 5). Optimizer-gaming prevention (Principle 7) ensures these gates are not compromised by data leakage from the optimization stage.
+
+---
+
+## Principle 7: Optimizer-Gaming Prevention
+
+**Failure mode prevented:** Implicit overfitting through validation set sizing — the optimizer indirectly learns the test distribution by exploiting the relationship between validation and test sets.
+
+This principle addresses a subtle but real failure mode that is distinct from the data leakage prevented by Principle 3. Even with perfect temporal separation, the optimizer can "game" the evaluation if the validation set design leaks information about the test set.
+
+Three mechanisms prevent this:
+
+1. **Validation-test parity.** The validation set used for early stopping (or model selection during training) should be the same size as the final test set. If the validation set is much smaller than the test set, the model optimizes for a statistically noisier signal, and lucky early-stopping points on the small validation set may not transfer to the larger test set. If validation is much larger, the model has more information to exploit during training than it will face at evaluation time.
+
+2. **Constant total test coverage.** When exploring different test set sizes as a hyperparameter, the total amount of data reserved for testing should remain constant. If doubling the test set size also doubles the total test data, you are changing two things at once — test window size and total test coverage. Hold total coverage constant (by adjusting the number of test windows) so that test size comparisons are fair.
+
+3. **Progressive range narrowing.** When running large hyperparameter searches, evaluate the full search on a broad configuration and then narrow the search range based on top-performing trials. This prevents the optimizer from memorizing specific configurations that happen to score well on a particular data window.
+
+These mechanisms compose with three-stage separation (Principle 4) to create a validation pipeline where no stage can implicitly influence another.
+
+**Composition with other principles:** This principle directly serves the integrity of three-stage separation (Principle 4). It also interacts with configuration-driven experimentation (Principle 8), which provides the mechanism for systematically exploring validation-set configurations.
+
+---
+
+## Principle 8: Configuration-Driven Experimentation
+
+**Failure mode prevented:** Experiment rot — research results that cannot be reproduced because parameters were hardcoded, modified in-place, or scattered across multiple files.
+
+A model specification should be data, not code. Concretely: every parameter that defines an experiment — prediction target, horizon, feature configuration, model architecture, training parameters, validation parameters — should live in a configuration file (YAML, JSON, or similar structured format) that is separate from the code that executes the experiment.
+
+This separation provides:
+
+1. **Reproducibility.** A configuration file is a complete record of an experiment. Given the same config and the same data, you get the same result. No ambiguity about which parameters were used.
+
+2. **Systematic exploration.** Running 50 experiments with different feature sets is trivial when each experiment is a config file. Running 50 experiments by editing code is error-prone and untrackable.
+
+3. **Version control.** Config files diff cleanly. You can see exactly what changed between two experiments. Code changes conflate parameter changes with logic changes.
+
+4. **Separation of concerns.** The code implements the *how* — how to compute features, how to train models, how to evaluate results. The config specifies the *what* — what features, what model, what evaluation criteria. This separation means you can change what you are experimenting with without touching how the pipeline works.
+
+Design your pipeline so that the configuration format is the primary interface. A new experiment should require only a new config file — not new code. When you find yourself modifying code to run a different experiment, that is a signal that your configuration format needs to be richer.
+
+**Composition with other principles:** Configuration-driven design makes horizon-adaptive parameterization (Principle 2) practical — the horizon and multipliers live in the config, and the code scales everything automatically. It makes optimizer-gaming prevention (Principle 7) systematic — validation set sizes, number of folds, and gap buffers are config parameters that can be varied in controlled experiments. It supports problem decomposition (Principle 9) by letting different sub-problems have their own configs.
+
+---
+
+## Principle 9: Problem Decomposition
+
+**Failure mode prevented:** Monolithic prediction — forcing a single model to learn a complex joint distribution when the problem has natural factorizations that simpler models can exploit.
+
+Many prediction problems can be decomposed into sub-problems that are individually easier to solve. This is a structural prior: if you can identify independent (or semi-independent) components of what you are predicting, modeling them separately and combining the predictions can outperform a monolithic approach.
+
+The principle is general. Possible decomposition strategies include:
+
+- **Regime conditioning.** Separate the problem by market regime (trending/mean-reverting, high-volatility/low-volatility). Build specialized models for each regime and a regime classifier to route predictions.
+
+- **Frequency decomposition.** Separate the signal into different frequency components (trend, cyclical, noise) and model each with appropriate techniques.
+
+- **Component factoring.** Decompose the target into components (e.g., a base rate and a deviation, or a conditional mean and a conditional variance) and model each component separately.
+
+- **Hierarchical modeling.** Predict at multiple levels of aggregation (individual asset, sector, market) and combine the predictions for consistency.
+
+Not every decomposition improves predictions. The value of decomposition depends on whether the sub-problems are genuinely more tractable than the joint problem. A decomposition that creates sub-problems that are highly interdependent, or that introduces recombination errors larger than the gains from specialization, will hurt rather than help.
+
+**How to evaluate decompositions:** Compare the decomposed pipeline against the monolithic baseline on your multi-threshold validation gates (Principle 6). The decomposition is justified only if it improves performance on the same independent evaluation windows. Be especially careful about recombination: the method used to combine sub-predictions is itself a modeling choice that can introduce bias or error.
+
+**Composition with other principles:** Each sub-problem in a decomposition should follow all other principles — physics-first features (Principle 1) for each component, horizon-adaptive parameters (Principle 2) where temporal features are involved, separate validation (Principles 4 and 6) for the combined output. Configuration-driven experimentation (Principle 8) makes decomposition strategies explorable without code changes.
+
+---
+
+## How the Principles Compose
+
+The nine principles are not independent rules to be checked off individually. They form a coherent system where each principle reinforces the others:
+
+**The modeling layer** (Principles 1, 2, 5, 9) determines what you build. Physics-first features define the estimation goals. Horizon-adaptive parameterization scales everything to the prediction window. The loss function encodes your beliefs about what matters. Problem decomposition structures how sub-problems are factored.
+
+**The integrity layer** (Principles 3, 4, 7) ensures what you build is honestly evaluated. Lookahead prevention guarantees you are not cheating. Three-stage separation prevents double-dipping. Optimizer-gaming prevention closes subtle leakage paths between stages.
+
+**The validation layer** (Principle 6) defines what "good enough" means. Multi-threshold quality gates prevent any single metric from flattering a bad model.
+
+**The infrastructure layer** (Principle 8) makes the whole system practical. Configuration-driven experimentation enables systematic exploration of the modeling choices defined by the modeling layer, evaluated through the integrity and validation layers.
+
+When building a prediction pipeline, you do not apply these principles sequentially. They constrain each other simultaneously. Your feature choices (Principle 1) must be computable without lookahead (Principle 3). Your validation gates (Principle 6) must operate within the three-stage framework (Principle 4). Your loss function (Principle 5) must be coherent with your estimation goals (Principle 1). Violating any principle weakens the entire system.
+
+The methodology is demanding because the problem is hard. Financial markets are adversarial environments where most apparent patterns are noise, overfitting is the default outcome, and there is no ground truth until you trade. These principles do not guarantee profitable models — nothing can. They guarantee that when a model passes your validation pipeline, the evidence for its predictive value is genuine.

--- a/allora_research_model_skills/shared/validation-framework.md
+++ b/allora_research_model_skills/shared/validation-framework.md
@@ -1,0 +1,264 @@
+# Validation Framework: Three-Stage Architecture and Quality Gates
+
+This document specifies how to evaluate financial prediction models honestly. It implements Principles 4 (three-stage separation), 6 (multi-threshold signal validation), and 7 (optimizer-gaming prevention) from the [methodology](./methodology.md).
+
+The core problem: evaluating a model on data that influenced its construction produces optimistically biased performance estimates. This bias is not small — it routinely turns worthless models into apparent successes. The three-stage architecture eliminates this bias through strict data separation, and multi-threshold quality gates ensure that models meeting the bar are genuinely useful.
+
+---
+
+## Why Standard Cross-Validation Fails for Time Series
+
+Standard k-fold cross-validation assumes samples are exchangeable — any sample can appear in any fold. Financial time series violate this assumption fundamentally:
+
+1. **Temporal autocorrelation.** Adjacent samples share information. If sample `t` is in the training set and sample `t+1` is in the test set, the model has already seen data highly correlated with the test point.
+
+2. **Feature lookback contamination.** Features computed with rolling or expanding windows incorporate historical data. A feature at time `t` depends on data from `t-W` to `t` (for window size `W`). If any of those historical points are in the test set of a different fold, information flows from test to train.
+
+3. **Non-stationarity.** The data-generating process changes over time. A random split mixes samples from different regimes, allowing the model to interpolate between regimes rather than extrapolate — which is what it must do in production.
+
+These are not edge cases. They are fundamental properties of financial time series. Any validation scheme that ignores them produces unreliable performance estimates.
+
+---
+
+## Stage 1: Inner Optimization (Hyperparameter Selection)
+
+### Purpose
+
+Find good hyperparameters through systematic search. This stage consumes data — the selected hyperparameters encode information about the training data, so inner CV scores are optimistically biased estimates of true performance.
+
+### Purged Walk-Forward Cross-Validation
+
+Walk-forward CV respects the temporal ordering of financial data. Each fold uses a contiguous block of past data for training and a subsequent contiguous block for testing, advancing through time:
+
+```
+Fold 1:  [====TRAIN====]--gap--[=TEST=]
+Fold 2:       [====TRAIN====]--gap--[=TEST=]
+Fold 3:            [====TRAIN====]--gap--[=TEST=]
+```
+
+**Purging** removes samples from the training set that are temporally close to the test set. **Gap buffers** insert an empty zone between training and test data. Together, they prevent information leakage through temporal autocorrelation and feature lookback windows.
+
+### Gap Buffer Sizing
+
+The gap buffer must be at least as large as the larger of:
+
+- **The prediction horizon.** If you predict `H` steps ahead, the target at time `t` depends on data at time `t+H`. Without a gap of at least `H`, training samples near the boundary have targets that overlap with the test period.
+
+- **The maximum feature lookback window.** If your longest feature uses a window of `W` steps, then a test sample at time `t` depends on data from `t-W` to `t`. Without a gap of at least `W`, training could include samples that share lookback data with test samples.
+
+In practice, use the maximum of both, plus a safety margin. Since horizon-adaptive parameterization (Principle 2) expresses all periods as multiples of `H`, the maximum feature lookback is typically some multiple `k * H`, making the gap buffer `k * H` plus margin.
+
+**Insufficient gap buffers are worse than no CV at all** — they create the illusion of honest evaluation while leaking information. When in doubt, make the gap larger. The cost is fewer effective training samples per fold; the benefit is honest scores.
+
+### Walk-Forward Design Choices
+
+Several structural choices affect the quality of inner CV:
+
+**Expanding vs. sliding window training.** Expanding windows use all data up to the current fold; sliding windows use a fixed-size lookback. Expanding windows give the model more data (better for small datasets) but assume older data is still relevant (worse in non-stationary markets). Sliding windows are more adaptive but require enough data per window for stable training.
+
+**Number of folds.** More folds give lower-variance CV score estimates but each fold has less unique test data. Fewer folds give noisier estimates but each fold is more independent. A reasonable starting point is 5-10 folds, ensuring each fold has enough test samples for the binomial tests used in validation (Principle 6).
+
+**Test fold size.** Each test fold should contain enough samples for statistical significance. For directional accuracy, a binomial test needs roughly 400+ predictions to have a reasonable chance of detecting a 55% accuracy rate, and 780+ for 80% statistical power (see the Statistical Rigor section below for the full derivation). Adjust based on your expected signal strength — weaker signals need more samples to detect.
+
+---
+
+## Stage 2: Outer Evaluation (Honest Assessment)
+
+### Purpose
+
+Obtain an unbiased estimate of out-of-sample performance using data that was never seen during Stage 1 — not even indirectly through hyperparameter selection.
+
+### Design Requirements
+
+**Independent time windows.** The outer evaluation uses time windows that are strictly later than (or otherwise separated from) all data used in Stage 1. These windows were not available to the optimizer in any form.
+
+**Fixed hyperparameters.** All hyperparameters are fixed to the values selected in Stage 1. No further tuning, no "just one more adjustment." Every modification after seeing outer evaluation data converts the outer evaluation into another round of inner optimization.
+
+**Fresh model training per window.** For each outer evaluation window, retrain the model from scratch on the training portion of that window (using the fixed hyperparameters), then evaluate on the held-out portion. This simulates what would happen in production: the model is trained on available history and evaluated on the subsequent period.
+
+**Multiple independent windows.** A single out-of-sample window is insufficient — performance on one window could be due to favorable market conditions. Multiple windows across different time periods provide confidence that performance is robust across regimes.
+
+### How to Partition Data
+
+The simplest approach: divide your full dataset into an inner portion (for Stage 1) and an outer portion (for Stage 2) along the time axis. The inner portion is earlier; the outer portion is later. A gap buffer separates them, sized the same way as the inner CV gap buffers.
+
+A more sophisticated approach uses nested walk-forward evaluation, where the outer evaluation itself walks forward through multiple windows, each time using all prior data for Stage 1 optimization and the next window for outer evaluation. This is computationally expensive but provides the most realistic simulation of production deployment.
+
+---
+
+## Optimizer-Gaming Prevention
+
+Even with strict Stage 1 / Stage 2 separation, the optimizer can implicitly game the evaluation through validation set design. Three mechanisms close these loopholes.
+
+### Validation-Test Parity
+
+**Principle:** The validation set used for early stopping during model training should be the same size as the test set used for evaluation.
+
+**Why this matters:** Early stopping monitors the validation loss and stops training when it begins to degrade. If the validation set is much smaller than the test set, the validation loss is noisier — the model may stop at a point that happens to look good on the noisy validation signal but performs poorly on the smoother test signal (or vice versa). Matching sizes ensures the statistical properties of the signal the model optimizes against match the signal it is evaluated on.
+
+**Implementation:** When you define your walk-forward folds, ensure the validation portion (used during training) is drawn from the end of the training block and has the same number of samples as the test portion.
+
+### Constant Total Test Coverage
+
+**Principle:** When exploring different test set sizes as a hyperparameter, hold the total number of test samples constant across configurations.
+
+**Why this matters:** If you double the test window size and also double the total test data (by using the same number of windows), you are changing two things simultaneously: the resolution of individual tests and the total data used for evaluation. This confounds the comparison.
+
+To maintain constant coverage: if you double the test window size, halve the number of test windows. The product `test_size * num_windows` stays constant. This ensures that differences in performance across configurations reflect the effect of test window size, not the effect of having more or less test data overall.
+
+**Formula:** `num_test_windows = const_test_epochs / test_size`, where `const_test_epochs` is a fixed constant representing the total test coverage budget.
+
+### Progressive Range Narrowing
+
+**Principle:** Run large hyperparameter searches in stages, narrowing the search range based on top-performing configurations.
+
+**Why this matters:** A single large search across all hyperparameter combinations risks the optimizer memorizing configurations that happen to perform well on specific data windows. Progressive narrowing mitigates this:
+
+1. Run a broad search across the full parameter space.
+2. Identify the top-performing configurations (e.g., top 20%).
+3. Narrow the search ranges to the region spanned by these top configurations.
+4. Run a finer search within the narrowed ranges.
+
+This converges toward robust configurations (those that perform well across the parameter space) rather than isolated lucky points.
+
+---
+
+## Multi-Threshold Signal Validation
+
+A model is accepted only if it simultaneously passes all quality gates. These gates are independent — they test different aspects of prediction quality that cannot substitute for each other.
+
+### Gate 1: Directional Accuracy
+
+**What it tests:** Does the model predict the correct sign of the target more often than chance?
+
+**How to measure:** Fraction of predictions where `sign(prediction) == sign(actual)`. Baseline is 50% for a symmetric target distribution (adjust if the target is significantly asymmetric).
+
+**Why it matters:** This is the minimum bar for predictive value. A model that cannot predict direction is not useful, regardless of its other properties.
+
+### Gate 2: Statistical Significance
+
+**What it tests:** Is the observed directional accuracy distinguishable from random guessing?
+
+**How to measure:** Apply a binomial test. Under the null hypothesis of random guessing, the number of correct directional predictions follows a Binomial(n, 0.5) distribution (or Binomial(n, p_base) if the baseline is not 50%). Compute the p-value for the observed accuracy.
+
+**Confidence intervals.** Report confidence intervals for directional accuracy, not just point estimates. An accuracy of 54% with a 95% CI of [48%, 60%] tells a very different story than 54% with a CI of [52%, 56%].
+
+**Why p-values alone are insufficient:** A p-value tells you whether the result is distinguishable from chance, not whether it is large enough to be useful. A model with 50.1% accuracy on 1 million predictions will have a tiny p-value but is practically worthless. Always pair statistical significance with practical significance (the other gates).
+
+### Gate 3: Calibration
+
+**What it tests:** Are prediction magnitudes informative? When the model predicts a large move, does a larger move actually occur?
+
+**How to measure:** Partition predictions by magnitude (e.g., quintiles) and verify that actual target magnitudes increase monotonically across quintiles. Alternatively, compute rank correlation between absolute prediction magnitude and absolute actual magnitude.
+
+**Why it matters:** A model that always predicts the same magnitude (just varying sign) passes the directional accuracy gate but carries no information about *how much* the target will move. Calibration ensures the model's confidence levels are meaningful.
+
+### Gate 4: Financial Improvement
+
+**What it tests:** Does the model improve financial outcomes relative to a simple baseline?
+
+**How to measure:** This is application-specific. Possible baselines include: no-trade (always predict zero), persistence (predict the same as the last observation), or simple moving average. The improvement metric should reflect your actual use case — information coefficient, Sharpe ratio improvement, PnL improvement, or whatever measures the value the model adds.
+
+**Why it matters:** A model can be statistically significant, directionally accurate, and well-calibrated, yet still not improve on a simple baseline if the simple baseline already captures most of the available signal. This gate ensures the model adds real value.
+
+### Composing the Gates
+
+A model passes validation if and only if it passes ALL gates simultaneously. The logic is:
+
+```
+passed = (
+    directional_accuracy > threshold_direction
+    AND p_value < threshold_significance
+    AND calibration_score > threshold_calibration
+    AND financial_improvement > threshold_improvement
+)
+```
+
+**Setting thresholds.** Thresholds should be set based on what would make the model useful in practice, not based on what current models achieve. This requires domain judgment: what directional accuracy is commercially meaningful? What financial improvement justifies deployment? Set these before evaluating any model to avoid hindsight bias.
+
+**Threshold independence.** Each gate tests a genuinely different property. A model cannot pass by being excellent on one gate and poor on others. This is by design — each gate catches a different class of failure that the others miss.
+
+---
+
+## Statistical Rigor
+
+### Binomial Tests for Directional Accuracy
+
+The binomial test is the appropriate significance test for directional accuracy because each prediction is a binary outcome (correct or incorrect direction) with a known baseline probability.
+
+**Requirements:**
+- Each prediction must be approximately independent. With purged walk-forward CV, this is ensured by gap buffers that remove temporal dependence.
+- The baseline probability must be correctly specified. For symmetric targets, use 0.5. For asymmetric targets (e.g., markets with upward drift), compute the empirical baseline from the target distribution.
+
+**Sample size considerations:** The minimum number of predictions needed depends on the signal strength you want to detect. To detect 55% accuracy (vs. 50% baseline) with 95% confidence and 80% power, you need approximately 780 predictions. Weaker signals need more data. Plan your test fold sizes accordingly.
+
+### Confidence Intervals
+
+Always report confidence intervals for key metrics, not just point estimates. For directional accuracy, the Wilson score interval is preferred over the normal approximation (it has better coverage properties for probabilities near 0 or 1, and for small sample sizes).
+
+For financial improvement metrics, bootstrap confidence intervals are appropriate — they make no distributional assumptions and handle the complex dependencies in financial returns.
+
+### Multiple Testing
+
+If you evaluate multiple model variants and select the best, you face a multiple testing problem — the more variants you try, the more likely one passes by chance. Account for this in Stage 2 by:
+
+1. **Pre-registering** which model variant you will evaluate in Stage 2 before looking at outer evaluation data.
+2. If evaluating multiple variants, applying a Bonferroni correction (or less conservative alternatives like Holm-Bonferroni) to your significance thresholds.
+3. Reporting the number of configurations evaluated alongside the final results.
+
+---
+
+## Deployment Validation
+
+Before committing to a full-data retrain, validate that the model generalizes beyond the evaluation set. This catches models that pass Stage 2 but exploit patterns specific to the evaluation period.
+
+**Three-partition approach:** Divide the outer portion into an evaluation set and a deployment set of equal size, separated by a gap buffer. Stage 2 evaluates on the evaluation set. Deployment validation retrains on all pre-deployment data (inner portion + evaluation set, minus gap buffer) and evaluates on the deployment set using the same quality gates.
+
+- If deployment validation passes: proceed to Stage 3.
+- If deployment validation fails: diagnose the gap between evaluation and deployment performance. Do NOT relax gate thresholds. The degradation between stages is itself a useful signal — modest degradation suggests mild overfitting; large degradation suggests the model captured regime-specific patterns rather than durable signal.
+
+## Production Deployment (Stage 3)
+
+Once a model passes all quality gates on both evaluation and deployment sets:
+
+1. **Retrain on all available data** using the selected hyperparameters. This maximizes the information available to the deployed model.
+
+2. **Lock the configuration.** The deployed model runs on the exact config that passed validation. No manual tweaks, no "I think this parameter should be slightly different."
+
+3. **Monitor for degradation.** Production models degrade over time as market conditions change. Define monitoring metrics and degradation thresholds that trigger re-evaluation. The monitoring metrics should align with your validation quality gates — if the model would no longer pass the gates on recent data, it needs retraining or replacement.
+
+4. **Scheduled re-evaluation.** Periodically run the full three-stage pipeline on updated data. This catches gradual degradation that single-metric monitoring might miss.
+
+---
+
+## Summary: The Validation Pipeline
+
+```
+Full Dataset
+  |
+  |-- [Inner Portion] -------> Stage 1: Purged Walk-Forward CV
+  |                              |
+  |                              |--> Hyperparameter search
+  |                              |--> Validation-test parity
+  |                              |--> Progressive range narrowing
+  |                              |--> Output: selected hyperparameters
+  |
+  |-- [gap buffer]
+  |
+  |-- [Evaluation Set] ------> Stage 2: Independent Evaluation
+  |                              |
+  |                              |--> Fixed hyperparameters from Stage 1
+  |                              |--> Multi-threshold quality gates
+  |                              |--> FAIL --> Back to Stage 1
+  |
+  |-- [gap buffer]
+  |
+  |-- [Deployment Set] ------> Deployment Validation
+                                 |
+                                 |--> Retrain on inner + evaluation data
+                                 |--> Same quality gates
+                                 |--> FAIL --> Diagnose, do not relax gates
+                                 |--> PASS --> Stage 3: Full-data retrain + deploy
+```
+
+Every element of this pipeline exists to prevent a specific failure mode. Removing any element opens a pathway for false confidence in model quality. The pipeline is demanding because the alternative — deploying models based on optimistic backtests — is how most quantitative strategies fail.

--- a/allora_research_model_skills/signal-discovery/SKILL.md
+++ b/allora_research_model_skills/signal-discovery/SKILL.md
@@ -1,0 +1,494 @@
+---
+name: forge-signal-discovery
+description: >
+  Guide creation of a prediction model for Allora using signal-discovery development methodology.
+  Produces a complete pipeline: data loading, feature engineering, model training, and validation.
+disable-model-invocation: true
+---
+
+# Signal Discovery Workflow
+
+You are guiding a builder through a data-first model development process. The builder has access to data — possibly unconventional data — and wants to discover what is predictable and build a model around it.
+
+Your role is to be a rigorous collaborator: ask questions, challenge assumptions, and enforce discipline. Do not make choices for the builder — guide them toward making well-reasoned choices themselves.
+
+## Methodology
+
+This workflow implements the nine-principle methodology documented in [the methodology overview](../shared/methodology.md). The principles are:
+
+1. Physics-first feature engineering — every feature measures a defined quantity
+2. Horizon-adaptive parameterization — all periods scale with the prediction horizon
+3. Lookahead prevention by construction — structural guardrails, not developer discipline
+4. Three-stage separation — optimize, evaluate, deploy with no information leakage between stages
+5. Loss function as a modeling decision — the loss encodes beliefs about what constitutes a good prediction
+6. Multi-threshold signal validation — simultaneous independent quality gates
+7. Optimizer-gaming prevention — validation equals test, constant test coverage
+8. Configuration-driven experimentation — specifications are data, not code
+9. Problem decomposition — factor predictions into sub-problems when structure supports it
+
+The signal-discovery path emphasizes principles 1, 2, 3, and 8: start from data, discover structure, engineer features with discipline, and manage experiments through configuration.
+
+Supporting material:
+- [Feature engineering guide](../shared/feature-engineering.md) — horizon-adaptive construction and lookahead prevention
+- [Loss design guide](../shared/loss-design.md) — loss as a modeling decision, CZAR for log-returns
+- [Validation framework](../shared/validation-framework.md) — three-stage architecture and quality gates
+
+---
+
+## Entry Point
+
+Begin every conversation with:
+
+**"What data do you have access to, and what's in it?"**
+
+Prompt the builder to describe:
+- What data sources are available (price feeds, on-chain data, social sentiment, order books, alternative data)
+- What fields/columns each source contains
+- What the time resolution is (tick, second, minute, hourly, daily)
+- How far back the history goes
+- Whether the data is already collected or requires API integration
+- Any known quality issues (gaps, duplicates, timezone inconsistencies)
+
+Do not proceed until you have a concrete inventory of available data. Vague descriptions ("I have some crypto data") are insufficient. Push for specifics.
+
+---
+
+## Guided Workflow
+
+### Phase 1: Data Inventory and Exploration
+
+**Objective:** Understand what the builder's data contains and whether it has predictive potential.
+
+**Step 1.1 — Load and inspect the data.**
+
+Guide the builder to write a data loader that:
+- Reads each data source into a structured format (DataFrame or equivalent)
+- Parses timestamps into a consistent timezone (UTC preferred)
+- Identifies the time resolution and checks for gaps
+- Reports basic statistics: row count, date range, column types, missing value rates
+
+The data loader is a pipeline artifact. It should be a standalone module that can be called from both exploration notebooks and the training pipeline.
+
+**Step 1.2 — Explore statistical properties.**
+
+Guide the builder through exploratory analysis of each data source:
+
+- **Distribution shapes.** Are the fields normally distributed, heavy-tailed, bounded, discrete? Plot histograms and QQ-plots.
+- **Temporal structure.** Is there autocorrelation? Seasonality? Regime changes visible in rolling statistics?
+- **Cross-correlations.** If multiple data sources are available, how do they correlate with each other? Do correlations change over time?
+- **Stationarity.** Are the raw fields stationary, or do they need differencing/returns transformation? Non-stationary features cause distribution shift between training and inference.
+
+Ask the builder: *"Based on what you see, what do you think might be predictable? What patterns stand out?"*
+
+This is where the builder's domain knowledge matters most. They may notice relationships that pure statistics would miss. Capture their hypotheses — these become the basis for feature design.
+
+**Step 1.3 — Identify candidate signals.**
+
+From the exploration, identify raw measurements that might contain predictive information. For each candidate:
+
+- What does it measure? (Map to an estimation goal — see the [feature engineering guide](../shared/feature-engineering.md))
+- Over what timescale does the signal operate? (Minutes, hours, days?)
+- Is it stationary or does it need transformation?
+- Can it be computed without future information?
+
+> **CHECKPOINT 1: Data Readiness**
+>
+> Before proceeding, verify:
+> - [ ] All data sources are loaded and inspectable
+> - [ ] Time alignment across sources is confirmed (common timezone, no off-by-one errors)
+> - [ ] Missing data is quantified and a handling strategy is decided (forward-fill, drop, interpolate)
+> - [ ] At least one candidate signal has been identified with a clear estimation goal
+> - [ ] The builder can articulate *why* they believe the signal might be predictive
+>
+> If the data is too sparse, too noisy, or the builder cannot identify any candidate signals, stop here and discuss whether the data supports model building.
+
+---
+
+### Phase 2: Feature Engineering
+
+**Objective:** Transform candidate signals into model-ready features with proper discipline.
+
+**Step 2.1 — Choose a prediction target.**
+
+Based on the exploratory findings, guide the builder to choose what they want to predict. The data should inform this choice — not the other way around.
+
+Ask the builder:
+- *"Given the signals you found, what prediction target would they most naturally serve?"*
+- *"What is the prediction horizon? How far ahead are you predicting?"*
+- *"What will the prediction be used for? (Trading decision, risk estimate, signal for another model?)"*
+
+The prediction target determines everything downstream: feature window sizes, loss function choice, and evaluation metrics.
+
+**Step 2.2 — Define the prediction horizon.**
+
+The prediction horizon `h` is the single most important parameter in the pipeline. All feature windows derive from it (see the [feature engineering guide](../shared/feature-engineering.md) for the full treatment).
+
+Guide the builder to choose `h` based on:
+- The timescale at which their signals operate (a signal that updates daily cannot usefully predict 5-minute returns)
+- The intended use case (high-frequency trading vs. daily rebalancing vs. weekly allocation)
+- Data availability (you need substantially more history than `h` for meaningful training)
+
+**Step 2.3 — Design features using the estimation-goal framework.**
+
+For each candidate signal identified in Phase 1, guide the builder through the three decisions:
+
+1. **What to measure.** Map the signal to an estimation goal (trend, mean reversion, volatility, microstructure, cross-asset, external signal).
+2. **Over what window.** Define windows as functions of the prediction horizon: sub-horizon (`h/4`, `h/2`), horizon-scale (`h`, `3h/2`), and super-horizon (`2h`, `5h`, `10h`).
+3. **How to normalize.** Choose a normalization that makes the feature approximately stationary and comparable across regimes (z-score over trailing window, percentile rank, volatility-scaled).
+
+**Step 2.4 — Enforce lookahead prevention.**
+
+This is non-negotiable. Guide the builder to implement these structural guardrails:
+
+- **Target construction.** Compute the target exactly once: `target[t] = f(data[t+h])`. This is the only operation that accesses future data.
+- **Feature computation.** All features use only data at or before time `t`. Rolling windows are trailing (end at `t`). No centered windows, no forward fills from future data.
+- **Column hygiene.** After target construction, drop all raw columns that contain future information from the feature matrix.
+- **External data joins.** Use as-of (point-in-time) joins: for each timestamp `t`, use the most recent external observation at or before `t`.
+
+Have the builder implement a verification function that checks every feature column for correlation with future target values at impossible lags. This is a safety net, not a replacement for correct construction.
+
+> **CHECKPOINT 2: Feature Integrity**
+>
+> Before proceeding to model training, verify:
+> - [ ] Every feature maps to a named estimation goal
+> - [ ] All feature windows are defined as functions of the prediction horizon `h`
+> - [ ] Target shift is computed exactly once, using the correct horizon
+> - [ ] No raw target or future-value columns remain in the feature matrix
+> - [ ] External data joins use as-of logic
+> - [ ] All rolling operations use trailing (past-only) windows
+> - [ ] Features are normalized using trailing statistics only
+> - [ ] A lookahead verification test passes (no impossible correlations)
+> - [ ] Features are computable at inference time with only past data available
+>
+> If any check fails, fix it before proceeding. Lookahead bugs do not produce errors — they produce suspiciously good results that disappear in production.
+
+---
+
+### Phase 3: Model and Loss Design
+
+**Objective:** Choose a model architecture and loss function appropriate to the discovered structure.
+
+**Step 3.1 — Choose a model architecture.**
+
+The model choice should follow from the data, not precede it. Guide the builder to consider:
+
+- **How much data is available?** Deep models need large datasets. With limited data, simpler models (gradient-boosted trees, linear models with engineered features) generalize better.
+- **What is the feature structure?** Tabular features with clear estimation goals work well with tree-based models. Sequential or spatial structure might warrant recurrent or convolutional architectures.
+- **What is the inference latency budget?** If the model must predict in real-time, complex architectures may be impractical.
+
+The builder should choose their own architecture based on these considerations. Do not prescribe a specific model.
+
+**Step 3.2 — Design the loss function.**
+
+Refer the builder to the [loss design guide](../shared/loss-design.md) and guide them through the design decisions:
+
+- **What errors matter most?** For directional predictions, wrong-direction errors are worse than magnitude errors. For risk estimates, underestimation is worse than overestimation.
+- **Should errors be volatility-normalized?** For return-based targets, usually yes. For bounded targets (sentiment scores), usually no.
+- **Is there a near-zero regime?** For return predictions, near-zero returns carry no directional information. For other targets, identify whether a similar ambiguous regime exists.
+
+If the prediction target is log-returns, introduce CZAR loss as a starting point and discuss whether its design dimensions match the builder's use case. For other targets, guide the builder through designing a custom loss using the three dimensions (directional asymmetry, volatility normalization, near-zero awareness) as a framework.
+
+**Step 3.3 — Define evaluation metrics.**
+
+The evaluation metrics capture what the builder actually cares about. These should be:
+- Independent of the loss function (not the same metric used for training)
+- Relevant to the downstream use case (if the prediction drives trading, evaluate on trading-relevant metrics)
+- Multiple and simultaneously applied (no single metric captures all aspects of prediction quality)
+
+Guide the builder to define at least three independent evaluation metrics. Common choices include directional accuracy, correlation between predicted and actual values, and a risk-adjusted performance measure.
+
+> **CHECKPOINT 3: Model Readiness**
+>
+> Before training, verify:
+> - [ ] Model architecture choice is justified by data size, feature structure, and latency requirements
+> - [ ] Loss function design dimensions are explicitly chosen and documented
+> - [ ] Evaluation metrics are defined, independent of the loss, and relevant to the use case
+> - [ ] The builder can explain why their loss and evaluation metrics are aligned but distinct
+>
+> If the builder cannot articulate why their loss is appropriate for their target, revisit the [loss design guide](../shared/loss-design.md).
+
+---
+
+### Phase 4: Three-Stage Validation
+
+**Objective:** Train, evaluate, and validate for deployment without information leakage between stages.
+
+Refer to the [validation framework](../shared/validation-framework.md) for the full architecture. The key points for signal-discovery builders:
+
+**Step 4.1 — Split the data into three temporal segments plus gap buffers.**
+
+- **Inner portion (optimization set).** Used for training and hyperparameter search via purged walk-forward CV (Stage 1). The model sees this data.
+- **Evaluation set.** Used for independent evaluation with fixed hyperparameters and multi-threshold quality gates (Stage 2). The model never trains on this data, but the builder makes decisions based on it (which model to keep, which features to include).
+- **Deployment set.** Held out completely. Used exactly once for deployment validation — to verify that evaluation-set performance was not an artifact of the builder's own selection process.
+
+Splits must be temporal (not random) with gap buffers between segments. The gap must be at least `max(h, max_feature_window)` to prevent leakage. The evaluation and deployment sets should be equal in length.
+
+**Step 4.2 — Stage 1: Train with purged walk-forward CV.**
+
+Within the inner portion, use purged walk-forward cross-validation for hyperparameter tuning. Standard k-fold cross-validation leaks information across time — never use it for time series.
+
+Gap buffers between each fold's training and validation segments prevent both target leakage and feature leakage. Validation set size within each fold should match the test portion size (validation-test parity).
+
+**Step 4.3 — Stage 2: Evaluate on evaluation set.**
+
+Train the model on the full inner portion using the hyperparameters selected in Stage 1. Run on the evaluation set and compute all evaluation metrics through multi-threshold quality gates. This is where the builder iterates:
+- If performance is poor, revisit feature engineering, loss design, or model architecture.
+- If performance is suspiciously good, investigate for lookahead leaks.
+- Compare multiple configurations systematically.
+
+If all quality gates pass, proceed to deployment validation.
+
+**Step 4.4 — Deployment validation.**
+
+Retrain the model on all pre-deployment data (inner portion + evaluation set, minus gap buffer) using the frozen hyperparameters from Stage 1. Evaluate on the deployment set using the same quality gates as Stage 2. This catches models that pass evaluation but exploit patterns specific to the evaluation period.
+
+- If deployment validation passes: proceed to Stage 3 (full-data retrain for production deployment).
+- If deployment validation fails: diagnose the gap between evaluation and deployment performance. Do NOT relax gate thresholds. The degradation between stages is itself a useful signal — modest degradation suggests mild overfitting; large degradation suggests the model captured regime-specific patterns rather than durable signal.
+
+**Step 4.5 — Stage 3: Full-data retrain.**
+
+If deployment validation passes, retrain on all available data (inner + evaluation + deployment) using the frozen hyperparameters. This maximizes training data for the deployed model. No further evaluation is performed — the deployment validation in Step 4.4 is the final honest assessment.
+
+> **CHECKPOINT 4: Validation Integrity**
+>
+> Verify:
+> - [ ] Data splits are temporal with appropriate gap buffers
+> - [ ] Evaluation and deployment sets are equal in length
+> - [ ] Cross-validation within the inner portion uses purged folds (not standard k-fold)
+> - [ ] Hyperparameters are frozen after Stage 1 — no further tuning in Stage 2 or deployment validation
+> - [ ] Deployment validation retrains on inner + evaluation data before evaluating on deployment set
+> - [ ] Deployment set is evaluated exactly once with no subsequent tuning or selection changes (Stage 3 full-data retrain uses frozen hyperparameters)
+> - [ ] If evaluation-deployment gap exists, the cause is documented
+> - [ ] Multiple evaluation metrics are reported (not just one)
+
+---
+
+### Phase 5: Configuration and Experimentation
+
+**Objective:** Structure the pipeline so experiments are data, not code changes.
+
+**Step 5.1 — Extract configuration.**
+
+Guide the builder to separate all tunable parameters into a configuration file (YAML, JSON, or TOML). The configuration should include:
+
+- **Data configuration.** Source paths, date ranges, asset universe, time resolution.
+- **Feature configuration.** Prediction horizon, feature definitions (estimation goals, window multipliers, normalization methods), feature selection criteria.
+- **Model configuration.** Architecture type, hyperparameters (learning rate, depth, regularization), training parameters (batch size, epochs, early stopping patience).
+- **Loss configuration.** Loss type, loss-specific parameters (directional penalty weight, volatility normalization window, zero-awareness transition scale).
+- **Validation configuration.** Split ratios, gap buffer sizes, cross-validation fold count, evaluation metric definitions and thresholds.
+- **Deployment configuration.** Inference frequency, prediction horizon, output format.
+
+The pipeline code reads the configuration and executes accordingly. To run a new experiment, create a new configuration file — do not modify code.
+
+**Step 5.2 — Establish experiment tracking.**
+
+Each experiment run should produce:
+- A copy of the configuration used
+- All evaluation metrics on optimization, evaluation, and deployment sets
+- Timestamps and data ranges for reproducibility
+- Any warnings or anomalies detected during training
+
+This record lets the builder compare experiments systematically and understand what changes led to improvements or regressions.
+
+**Step 5.3 — Design the experiment progression.**
+
+Guide the builder to plan their experiments as a structured sequence, not random exploration:
+
+1. **Baseline.** Simple model, minimal features, standard loss. Establishes the floor.
+2. **Feature expansion.** Add features one estimation goal at a time. Verify each addition improves validation performance.
+3. **Loss refinement.** Switch from standard to custom loss. Compare directional accuracy and magnitude accuracy.
+4. **Hyperparameter tuning.** Systematic search over model hyperparameters with the best feature set and loss.
+5. **Robustness check.** Evaluate across multiple time windows, different market regimes, and different assets (if applicable).
+
+Each step is a configuration change, not a code change. The configuration file is the experiment record.
+
+> **CHECKPOINT 5: Experiment Discipline**
+>
+> Verify:
+> - [ ] All tunable parameters are in the configuration file, not hardcoded
+> - [ ] The pipeline runs end-to-end from a configuration file without code modification
+> - [ ] Each experiment is recorded (configuration + results)
+> - [ ] Experiments follow a structured progression (baseline → expand → refine → tune → robustness)
+
+---
+
+### Phase 6: Problem Decomposition (When Applicable)
+
+**Objective:** Assess whether the prediction problem benefits from decomposition into sub-problems.
+
+Not every problem should be decomposed. Decomposition adds complexity and is only worthwhile when the sub-problems have genuinely different structure that benefits from separate modeling.
+
+**Step 6.1 — Assess decomposition candidates.**
+
+Guide the builder to ask:
+- *"Does the prediction target have identifiable components that vary on different timescales?"* (e.g., a slow-moving trend component and a fast mean-reverting component)
+- *"Are there sub-problems that would benefit from different feature sets or model architectures?"*
+- *"Can the sub-problems be combined into the final prediction through a known functional form?"*
+
+If the answer to all three is no, skip decomposition. A single well-designed model is simpler and often more robust.
+
+**Step 6.2 — If decomposing, maintain independence.**
+
+Each sub-model should:
+- Have its own feature set (though features may overlap)
+- Have its own loss function appropriate to the sub-problem
+- Be validated independently before combination
+- Be combined through a transparent aggregation function
+
+The combination function should be simple (addition, multiplication, weighted average) — not a learned ensemble, which introduces a new optimization layer and new overfitting risk.
+
+---
+
+### Phase 7: Deployment Preparation
+
+**Objective:** Package the model for inference in the Allora network.
+
+**Step 7.1 — Verify inference-time compatibility.**
+
+The model must produce predictions using only data available at inference time. Verify:
+- All features are computable from a trailing data window (no full-history dependencies)
+- The data loader can fetch current data from the same sources used in training
+- Feature engineering code is shared between training and inference (single implementation)
+- The model can produce a prediction within the required latency
+
+**Step 7.2 — Build the monitoring pipeline.**
+
+Guide the builder to create a monitoring module that handles both live inference and ongoing model health checks:
+
+1. **Live inference:** Fetches current data from configured sources, computes features using the same feature-engineering code as training, runs the trained model to produce a prediction, and formats the output for submission to the Allora network.
+2. **Performance monitoring:** Tracks live predictions against realized outcomes. Defines a threshold for when live performance has degraded enough to trigger re-evaluation.
+3. **Feature monitoring:** Tracks feature distributions and flags when any feature drifts significantly from its training-time distribution.
+4. **Staleness check:** Enforces a maximum model age. Even if performance has not degraded, the model should be periodically re-validated on fresh data.
+5. **Rebuild trigger:** Defines the degradation threshold that triggers a full rebuild using the same validation framework.
+
+**Step 7.3 — Document the model.**
+
+The builder should produce a brief model card documenting:
+- What the model predicts (target, horizon, asset)
+- What data sources it uses
+- What the validation performance was (all metrics)
+- Known limitations or regime dependencies
+- Configuration used for the deployed version
+
+---
+
+## Output Specification
+
+At the end of the workflow, the builder should have produced these artifacts:
+
+### Pipeline Artifacts
+
+| Artifact | Description | File |
+|---|---|---|
+| **Configuration** | All parameters in a single config file | `config.yaml` |
+| **Data Loader** | Module that fetches and normalizes data from all sources | `data_loader.py` |
+| **Feature Engineer** | Module that transforms raw data into model features | `feature_engineer.py` |
+| **Model + Loss** | Model definition and custom loss function | `model.py` |
+| **Pipeline Orchestrator** | End-to-end three-stage validation and evaluation | `evaluate.py` |
+| **Validation Suite** | Quality gates as executable pass/fail checks | `validation.py` |
+| **Evaluation Report** | Results from evaluation and deployment validation | `evaluation_report.md` |
+| **Monitoring Module** | Live inference and post-deployment monitoring: performance tracking, feature drift detection, staleness checks | `monitor.py` |
+
+### Configuration Structure
+
+The configuration file should contain all parameters needed to reproduce the experiment:
+
+```yaml
+# Prediction problem
+target:
+  name: <what is being predicted>
+  horizon_bars: <h, number of bars>
+  asset: <asset identifier>
+
+# Data source
+data:
+  exchange: <exchange name>
+  interval: <bar size>
+  start: <earliest data to use>
+  end: <latest data to use>
+
+# Three-stage partition boundaries
+partitions:
+  optimization_end: <end of optimization period>
+  evaluation_end: <end of evaluation period>
+  deployment_end: <end of deployment period>
+  gap_bars: <gap buffer size in bars>
+
+# Features grouped by estimation goal
+features:
+  <estimation_goal>:
+    - name: <feature name>
+      window: <lookback in bars, as multiple of h>
+      description: <what this measures>
+
+# Model architecture
+model:
+  type: <model type>
+  task: <regression or classification>
+
+# Loss function (top-level, not inside model)
+loss:
+  name: <loss function name>
+  <loss-specific parameters>
+
+# Baseline loss for comparison
+comparison_loss: <baseline loss name>
+
+# Hyperparameter search
+hyperparameter_search:
+  method: <search method>
+  params:
+    <param_name>: <search values>
+
+# Walk-forward cross-validation (Stage 1)
+walk_forward_cv:
+  n_folds: <number>
+  expanding_window: <true or false>
+  gap_bars: <gap buffer size>
+
+# Quality gates
+gates:
+  <gate_name>:
+    threshold: <threshold value>
+
+# Output
+output_dir: <path>
+```
+
+### Quality Gates
+
+The model is ready for deployment only when ALL of the following pass simultaneously:
+
+- All checkpoint verifications (1 through 5) are satisfied
+- Evaluation-set performance exceeds minimum thresholds on ALL defined metrics (not just one)
+- Deployment validation passes with the same quality gates (retrained on inner + evaluation data)
+- No lookahead violations detected
+- Inference pipeline produces predictions from live data
+- Model card is complete
+
+If any gate fails, the model is not ready. Go back to the relevant phase and iterate.
+
+---
+
+## Workflow Summary
+
+```
+Data Inventory           What do you have?
+    |
+Exploration              What patterns exist?
+    |
+Feature Engineering      Disciplined signal construction
+    |                    (horizon-adaptive, lookahead-safe)
+    |
+Model + Loss Design      Architecture and loss from the data's structure
+    |
+Three-Stage Validation   Optimize → evaluate (+ deployment gate) → retrain + deploy
+    |
+Configuration            Parameters as data, experiments as configs
+    |
+[Decomposition]          Only if sub-problem structure exists
+    |
+Deployment               Inference pipeline + model card
+```
+
+The builder's data and discoveries drive every decision. The methodology provides the discipline. The result is a model that works in production because it was built to work in production from the start.


### PR DESCRIPTION
## Summary

Adds a new top-level folder `allora_research_model_skills/` containing three Claude Code skills (plus shared methodology docs) that guide builders through constructing financial prediction models from three different starting points:

- **hypothesis-driven** — deductive: start from a theory, build features to test it
- **signal-discovery** — inductive: start from data, discover what is predictable
- **robustness-first** — adversarial: start from validation gates, work backwards

`shared/` contains the common nine-principle methodology, feature engineering, loss design, and validation framework documentation that all three skills build on. The top-level `README.md` explains when to pick which skill.

## Why a separate top-level folder

The existing `skills/` folder hosts single-skill packages (`allora-data-exploration`, `allora-model-builder`, `allora-worker-manager`). This contribution is a curated bundle of three sibling methodology skills with their own README and shared docs, so it lives at the top level alongside `skills/` rather than inside it. Open to moving it under `skills/` if reviewers prefer.

## Excluded

The source folder includes a `test/` subdirectory with internal dry-run output and a test scenario; that's deliberately not copied — it's internal validation, not user-facing material.

## Test plan

- [x] Documentation-only addition; no runtime code changed
- [x] Confirm files render correctly on GitHub
- [x] Confirm CI is green (no path-restricted workflow should be triggered by docs-only changes)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `allora_research_model_skills/` bundle with three methodology-first model-building skills and shared docs. Updates the root `README.md` with Model creation skills, a learning problem primer, TOC/diagram, and a small docs cleanup; docs-only, no runtime code.

- **New Features**
  - Bundle: three skills — `forge-hypothesis-driven`, `forge-signal-discovery`, `forge-robustness-first`; bundle `README.md` explains when to use each.
  - Shared docs: `methodology.md` (nine principles), `feature-engineering.md`, `loss-design.md`, `validation-framework.md`.
  - Root `README.md`: adds “Model creation skills” with a selection table and links; adds “The learning problem” primer; updates Contents TOC and adds an ASCII submission→evaluation→scores diagram; aligns Python prerequisite to 3.10+; removes a duplicate skills list in “The learning problem” and links to the new section instead.

<sup>Written for commit 438573618ec136c77a698a6ade2448b039954903. Summary will update on new commits. <a href="https://cubic.dev/pr/allora-network/allora-forge-builder-kit/pull/25?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

