### PR TITLE
Update Testnet ID for BTC/USD Log Returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Mainnet topics and their testnet equivalents:
 
 | Mainnet ID | Mainnet Name | Testnet ID | Testnet Name |
 |-----------|-------------|-----------|-------------|
-| 1  | BTC/USD - Log Returns - 8h  | 64 | 8h BTC/USD Log-Return (5min updates) |
+| 1  | BTC/USD - Log Returns - 8h  | 65 | 8h BTC/USD Log-Return (5min updates) |
 | 2  | ETH/USD - Log Returns - 8h  | — | Missing |
 | 3  | SOL/USD - Log Returns - 8h  | 57 | 8h SOL/USD Log-Return *(inactive)* |
 | 9  | ETH/USD - Price Prediction - 8h | 41 | ETH/USD - 8h Price Prediction |


### PR DESCRIPTION
Need to update the Topic ID list. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the README to change the testnet topic ID for "BTC/USD - Log Returns - 8h" from 64 to 65 so the mainnet-to-testnet mapping is accurate.

<sup>Written for commit 8bee90eb3b94a63a948e80a123a3881bb4ec4a78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

