### PR TITLE
ENGN-8614: add `workerctl link` device-flow CLI for wallet ownership

### DIFF
--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -215,9 +215,12 @@ def run_link(
     print()
     if open_browser:
         try:
-            webbrowser.open(verification_uri_complete)
+            opened = webbrowser.open(verification_uri_complete)
+        except Exception:  # pragma: no cover - some platforms raise instead of returning False
+            opened = False
+        if opened:
             print("Opened your browser. Waiting for approval...")
-        except Exception:  # pragma: no cover - headless / no browser
+        else:
             print("Could not open a browser; open the URL above. Waiting...")
     else:
         print("Waiting for approval...")

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -27,7 +27,7 @@ import urllib.error
 import urllib.request
 import webbrowser
 from pathlib import Path
-from typing import Optional, TypedDict
+from typing import Any, Optional, TypedDict
 from urllib.parse import urlparse
 
 DEFAULT_FORGE_URL = "https://forge.allora.network"
@@ -105,7 +105,7 @@ def discover_keys(secrets_path: str | Path) -> dict[str, _KeyEntry]:
     return out
 
 
-def _post_json(url: str, payload: dict, timeout: float = 15.0) -> dict:
+def _post_json(url: str, payload: dict[str, Any], timeout: float = 15.0) -> dict[str, Any]:
     body = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(
         url, data=body, headers={"Content-Type": "application/json"}, method="POST"

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -34,6 +34,7 @@ from urllib.parse import urlparse
 DEFAULT_FORGE_URL = "https://forge.allora.network"
 DEFAULT_SECRETS_PATH = "worker_secrets.json"
 _POLL_TIMEOUT_SECONDS = 600
+_MAX_RESPONSE_BYTES = 512 * 1024
 
 
 # A single discovered worker key entry from worker_secrets.json.
@@ -120,9 +121,9 @@ def _post_json(url: str, payload: dict[str, Any], timeout: float = 15.0) -> dict
     )
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return json.loads(resp.read().decode("utf-8"))
+            return json.loads(resp.read(_MAX_RESPONSE_BYTES).decode("utf-8"))
     except urllib.error.HTTPError as exc:
-        detail = exc.read().decode("utf-8", "replace")
+        detail = exc.read(_MAX_RESPONSE_BYTES).decode("utf-8", "replace")
         raise SystemExit(f"request to {url} failed ({exc.code}): {detail}") from exc
     except urllib.error.URLError as exc:
         raise SystemExit(f"could not reach {url}: {exc.reason}") from exc

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -234,7 +234,9 @@ def _loads_json_object(url: str, raw: str) -> dict[str, Any]:
     try:
         parsed = json.loads(raw)
     except json.JSONDecodeError as exc:
-        raise SystemExit(f"request to {url} returned non-JSON: {raw[:200]!r}") from exc
+        # Sanitize the server-controlled body through _printable before it reaches stderr, matching
+        # the HTTP-error path; otherwise a non-JSON response could inject terminal escape sequences.
+        raise SystemExit(f"request to {url} returned non-JSON: {_printable(raw[:200])!r}") from exc
     if not isinstance(parsed, dict):
         raise SystemExit(f"request to {url} returned unexpected JSON type: {type(parsed).__name__}")
     return parsed

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -70,8 +70,8 @@ def sign_challenge(mnemonic: str, address: str, message: str) -> tuple[str, str]
         from cosmpy.aerial.wallet import LocalWallet
     except ImportError as exc:  # pragma: no cover - environment guard
         raise SystemExit(
-            "cosmpy is required to sign. Install the builder kit deps "
-            "(pip install -e . / cosmpy==0.11.1)."
+            "cosmpy is required to sign. Install the wallet-link extra "
+            "(pip install 'allora-forge-builder-kit[wallet-link]') or cosmpy==0.11.1."
         ) from exc
 
     wallet = LocalWallet.from_mnemonic(mnemonic, "allo")

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -28,6 +28,7 @@ import urllib.request
 import webbrowser
 from pathlib import Path
 from typing import Optional
+from urllib.parse import urlparse
 
 DEFAULT_FORGE_URL = "https://forge.allora.network"
 DEFAULT_SECRETS_PATH = "worker_secrets.json"
@@ -118,9 +119,22 @@ def run_link(
     secrets_path: str = DEFAULT_SECRETS_PATH,
     addresses: Optional[list[str]] = None,
     open_browser: bool = True,
+    insecure: bool = False,
 ) -> int:
     """Drive the full device flow. Returns a process exit code."""
     forge_url = forge_url.rstrip("/")
+    parsed = urlparse(forge_url)
+    if (
+        parsed.scheme != "https"
+        and parsed.hostname not in ("localhost", "127.0.0.1")
+        and not insecure
+    ):
+        print(
+            f"refusing plaintext forge URL {forge_url} "
+            f"(use --insecure to override for local dev)",
+            file=sys.stderr,
+        )
+        return 1
     keys = discover_keys(secrets_path)
     if not keys:
         print(
@@ -241,12 +255,18 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument(
         "--no-browser", action="store_true", help="Do not auto-open a browser"
     )
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help="Allow a plaintext http:// forge URL (local dev only)",
+    )
     args = parser.parse_args(argv)
     return run_link(
         forge_url=args.forge_url,
         secrets_path=args.secrets_path,
         addresses=args.addresses,
         open_browser=not args.no_browser,
+        insecure=args.insecure,
     )
 
 

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -510,6 +510,19 @@ def run_link(
         )
         return 1
 
+    # Pre-validate the optional cosmpy dependency here, before /device/start opens a server-side
+    # session. sign_challenge imports cosmpy lazily; without this check a missing wallet-link extra
+    # would fail only after the session exists, orphaning it until the janitor reaps it (~15 min).
+    try:
+        from cosmpy.aerial.wallet import LocalWallet  # noqa: F401
+    except ImportError:
+        print(
+            "cosmpy is required to sign. Install the wallet-link extra "
+            "(pip install 'allora-forge-builder-kit[wallet-link]') or cosmpy==0.11.1.",
+            file=sys.stderr,
+        )
+        return 1
+
     print(f"Linking {len(selected)} worker address(es) to Allora Forge at {forge_url}")
 
     # 1. Start the device session.

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import base64
 import json
+import os
 import re
 import sys
 import time
@@ -95,6 +96,26 @@ def sign_challenge(mnemonic: str, address: str, message: str) -> tuple[str, str]
     return pubkey_b64, signature_b64
 
 
+def _checked_key_file(base: str, address: str, key_file: str) -> str:
+    """Warn (without rejecting) when a secrets key_file resolves outside the secrets dir."""
+    kf = Path(key_file).expanduser()
+    kf_abs = os.path.abspath(kf if kf.is_absolute() else Path(base) / kf)
+    try:
+        outside = os.path.commonpath((base, kf_abs)) != base
+    except ValueError:  # different drives / mixed path kinds
+        outside = True
+    if outside:
+        # The threat model already grants mnemonic access; this just surfaces a
+        # tampered worker_secrets.json that redirects a read outside the dir.
+        # We don't reject because legitimate absolute key_file paths are normal.
+        print(
+            f"warning: key_file for {address} resolves outside the secrets dir "
+            f"{base}; reading it anyway ({key_file})",
+            file=sys.stderr,
+        )
+    return key_file
+
+
 def discover_keys(secrets_path: str | Path) -> dict[str, _KeyEntry]:
     """Load WorkerManager secrets: {address: {"alias", "key_file"}}."""
     path = Path(secrets_path)
@@ -107,10 +128,14 @@ def discover_keys(secrets_path: str | Path) -> dict[str, _KeyEntry]:
         # instead of masking it as the "no worker keys, create one" case.
         print(f"could not read worker secrets at {secrets_path}: {exc}", file=sys.stderr)
         return {}
+    base = os.path.dirname(os.path.abspath(path))
     out: dict[str, _KeyEntry] = {}
     for alias, entry in raw.items():
         if isinstance(entry, dict) and entry.get("address") and entry.get("key_file"):
-            out[entry["address"]] = {"alias": alias, "key_file": entry["key_file"]}
+            out[entry["address"]] = {
+                "alias": alias,
+                "key_file": _checked_key_file(base, entry["address"], entry["key_file"]),
+            }
     return out
 
 

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -184,9 +184,15 @@ def run_link(
     deadline = time.time() + _POLL_TIMEOUT_SECONDS
     while time.time() < deadline:
         time.sleep(max(1, interval))
-        poll = _post_json(
-            f"{forge_url}/api/v1/wallet-link/device/poll", {"device_code": device_code}
-        )
+        try:
+            poll = _post_json(
+                f"{forge_url}/api/v1/wallet-link/device/poll", {"device_code": device_code}
+            )
+        except SystemExit as exc:
+            # Transient HTTP/network error (502/503/429, DNS blip): keep polling
+            # until our wall-clock deadline instead of aborting the whole flow.
+            print(f"  (poll error: {exc}; retrying...)", file=sys.stderr)
+            continue
         status = poll.get("status")
         if status == "approved":
             linked = poll.get("linked", [])

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -215,12 +215,13 @@ class _RequestError(SystemExit):
 def _is_terminal_poll_error(exc: BaseException) -> bool:
     """True when a poll error should stop the device flow immediately rather than be retried.
 
-    Terminal = a 4xx client error other than 408/429 (e.g. the device code is expired, invalid, or
-    already used): every retry returns the same response until the deadline. 5xx, 408, 429, network
-    blips, and malformed-body errors (no ``status``) are transient and keep polling.
+    Terminal = a 3xx redirect (an origin/scheme misconfiguration that never resolves by retrying) or
+    a 4xx client error other than 408/429 (e.g. the device code is expired, invalid, or already
+    used): every retry returns the same response until the deadline. 5xx, 408, 429, network blips,
+    and malformed-body errors (no ``status``) are transient and keep polling.
     """
     status = getattr(exc, "status", None)
-    return status is not None and 400 <= status < 500 and status not in (408, 429)
+    return status is not None and 300 <= status < 500 and status not in (408, 429)
 
 
 def _loads_json_object(url: str, raw: str) -> dict[str, Any]:
@@ -449,19 +450,30 @@ class _JsonPoster:
             headers["Proxy-Authorization"] = self._proxy_auth
         # Retry once: the server may have dropped an idle keep-alive connection between polls.
         for attempt in (1, 2):
-            if self._conn is None:
-                self._conn = self._connect()
             try:
+                if self._conn is None:
+                    # Inside the try so a DNS/proxy/connect failure (OSError/HTTPException) becomes a
+                    # retryable _RequestError rather than an unhandled traceback escaping the loop.
+                    self._conn = self._connect()
                 self._conn.request("POST", request_target, body=body, headers=headers)
                 resp = self._conn.getresponse()
                 data = resp.read(_MAX_RESPONSE_BYTES)
-                if resp.status >= 400:
+                if resp.status >= 300:
+                    # >= 300 (not just >= 400): the poll endpoint always answers 200, so a 3xx is a
+                    # misconfiguration (e.g. an http->https redirect). Treating it as an error stops
+                    # it falling through to _loads_json_object and spinning the loop to the deadline.
                     detail = _printable(data.decode("utf-8", "replace"))
                     # Close before raising: _RequestError (a BaseException) escapes the except below,
                     # so an undrained connection would defeat keep-alive.
                     self.close()
                     raise _RequestError(f"request to {url} failed ({resp.status}): {detail}", status=resp.status)
-                return _loads_json_object(url, data.decode("utf-8", "replace"))
+                try:
+                    return _loads_json_object(url, data.decode("utf-8", "replace"))
+                except SystemExit:
+                    # A malformed 200 body raises SystemExit (a BaseException the except below won't
+                    # catch); close so the next poll reconnects instead of reusing a dirty socket.
+                    self.close()
+                    raise
             except (http.client.HTTPException, OSError) as exc:
                 self.close()
                 if attempt == 2:

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -91,7 +91,7 @@ def sign_challenge(mnemonic: str, address: str, message: str) -> tuple[str, str]
     signer = wallet.signer()
     doc = build_adr036_sign_doc(address, message)
     signature = signer.sign(doc)
-    pubkey_b64 = base64.standard_b64encode(signer.public_key_bytes).decode("ascii")
+    pubkey_b64 = base64.standard_b64encode(signer.public_key.public_key_bytes).decode("ascii")
     signature_b64 = base64.standard_b64encode(signature).decode("ascii")
     return pubkey_b64, signature_b64
 

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -27,12 +27,18 @@ import urllib.error
 import urllib.request
 import webbrowser
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TypedDict
 from urllib.parse import urlparse
 
 DEFAULT_FORGE_URL = "https://forge.allora.network"
 DEFAULT_SECRETS_PATH = "worker_secrets.json"
 _POLL_TIMEOUT_SECONDS = 600
+
+
+# A single discovered worker key entry from worker_secrets.json.
+class _KeyEntry(TypedDict):
+    alias: str
+    key_file: str
 
 
 def build_adr036_sign_doc(signer: str, message: str) -> bytes:
@@ -83,7 +89,7 @@ def sign_challenge(mnemonic: str, address: str, message: str) -> tuple[str, str]
     return pubkey_b64, signature_b64
 
 
-def discover_keys(secrets_path: str | Path) -> dict[str, dict]:
+def discover_keys(secrets_path: str | Path) -> dict[str, _KeyEntry]:
     """Load WorkerManager secrets: {address: {"alias", "key_file"}}."""
     path = Path(secrets_path)
     if not path.exists():
@@ -92,7 +98,7 @@ def discover_keys(secrets_path: str | Path) -> dict[str, dict]:
         raw = json.loads(path.read_text())
     except (json.JSONDecodeError, OSError):
         return {}
-    out: dict[str, dict] = {}
+    out: dict[str, _KeyEntry] = {}
     for alias, entry in raw.items():
         if isinstance(entry, dict) and entry.get("address") and entry.get("key_file"):
             out[entry["address"]] = {"alias": alias, "key_file": entry["key_file"]}

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -276,6 +276,40 @@ def _post_json(url: str, payload: dict[str, Any], timeout: float = 15.0) -> dict
         raise _RequestError(f"could not reach {url}: {exc.reason}") from exc
 
 
+def _post_json_retrying(
+    url: str, payload: dict[str, Any], *, attempts: int = 3, backoff: float = 2.0
+) -> dict[str, Any]:
+    """POST JSON with a bounded retry on transient (non-terminal) failures.
+
+    Retries a network error or a transient HTTP status (5xx / 408 / 429) up to ``attempts`` times
+    with ``backoff`` seconds between tries, and re-raises a terminal 4xx immediately (retrying an
+    expired/invalid device code just returns the same error). Used for ``/device/submit`` so a
+    single network blip after the challenges are signed doesn't abort the run and orphan the
+    server-side session — the server's ``MarkChallengeProven`` is idempotent, so replaying the same
+    signatures is safe.
+
+    Args:
+        url: Absolute request URL.
+        payload: JSON-serializable request body.
+        attempts: Maximum number of tries (>= 1).
+        backoff: Seconds to sleep between tries.
+
+    Returns:
+        The parsed JSON object from the first successful response.
+
+    Raises:
+        _RequestError: On a terminal failure or after the final attempt.
+    """
+    for attempt in range(1, attempts + 1):
+        try:
+            return _post_json(url, payload)
+        except _RequestError as exc:
+            if attempt == attempts or _is_terminal_poll_error(exc):
+                raise
+            time.sleep(backoff)
+    raise _RequestError(f"could not reach {url}")  # unreachable: the loop returns or raises
+
+
 def _printable(text: str) -> str:
     """Drop non-printable chars so server strings can't inject terminal escapes."""
     return "".join(c for c in text if c.isprintable())
@@ -613,7 +647,9 @@ def run_link(
             {"address": address, "pubkey": pubkey_b64, "signature": signature_b64}
         )
 
-    submit = _post_json(
+    # Retry submit on a transient failure: the challenges are already signed, so a single network
+    # blip here would otherwise abort the run and orphan the server session. Idempotent server-side.
+    submit = _post_json_retrying(
         f"{forge_url}/api/v1/wallet-link/device/submit",
         {"device_code": device_code, "signatures": signatures},
     )

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -142,6 +142,10 @@ def run_link(
     start = _post_json(
         f"{forge_url}/api/v1/wallet-link/device/start", {"addresses": selected}
     )
+    for field in ("device_code", "user_code", "verification_uri_complete"):
+        if not start.get(field):
+            print(f"server response missing required field: {field}", file=sys.stderr)
+            return 1
     device_code = start["device_code"]
     user_code = start["user_code"]
     verification_uri_complete = start["verification_uri_complete"]
@@ -150,7 +154,11 @@ def run_link(
     except (TypeError, ValueError):
         interval = 5
     interval = max(1, min(interval, 60))
-    challenges = {c["address"]: c["message"] for c in start.get("challenges", [])}
+    challenges = {
+        c["address"]: c["message"]
+        for c in start.get("challenges", [])
+        if isinstance(c, dict) and c.get("address") and c.get("message")
+    }
 
     # 2. Sign each challenge locally and submit the signatures.
     signatures = []

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -285,8 +285,15 @@ def run_link(
     else:
         print("Waiting for approval...")
 
-    # 4. Poll until the user approves/denies or the session expires.
-    deadline = time.time() + _POLL_TIMEOUT_SECONDS
+    # 4. Poll until the user approves/denies or the session expires. Honor the
+    # server-advertised expires_in (clamped) so the client deadline tracks the
+    # real session TTL instead of a fixed local constant.
+    try:
+        timeout = int(start.get("expires_in", _POLL_TIMEOUT_SECONDS))
+    except (TypeError, ValueError):
+        timeout = _POLL_TIMEOUT_SECONDS
+    timeout = max(1, min(timeout, _POLL_TIMEOUT_SECONDS))
+    deadline = time.time() + timeout
     while time.time() < deadline:
         time.sleep(max(1, interval))
         try:

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -41,6 +41,12 @@ DEFAULT_SECRETS_PATH = "worker_secrets.json"
 # server still considers live (e.g. an approval delayed by MFA or a device switch).
 _POLL_TIMEOUT_SECONDS = 1800
 _MAX_RESPONSE_BYTES = 512 * 1024
+# Recognized "keep polling" statuses from /device/poll. forge-v2 returns "authorization_pending";
+# "pending"/"slow_down" are accepted defensively for forward-compat with the RFC 8628 device flow.
+_POLL_PENDING_STATUSES = frozenset({"authorization_pending", "pending", "slow_down"})
+# Give up after this many consecutive non-progress polls (transport/parse errors or an unrecognized
+# status) so a persistently broken response fails fast instead of polling until the deadline.
+_MAX_CONSECUTIVE_POLL_FAILURES = 10
 # Loopback hosts treated as safe for plaintext HTTP / verification-URL origin pinning. Includes the
 # IPv6 loopback ::1 (urlparse('http://[::1]/').hostname == '::1', no brackets) so a local Forge bound
 # to [::1] on a dual-stack host doesn't require --insecure.
@@ -701,6 +707,9 @@ def run_link(
     # Reuse one keep-alive connection across the (up to ~120) polls to the same Forge host
     # instead of a fresh TCP+TLS handshake per poll.
     poller = _JsonPoster(forge_url)
+    # Bound consecutive non-progress polls (transport/parse errors or an unrecognized status) so a
+    # persistently broken response can't silently poll — and flood stderr — until the deadline.
+    consecutive_unexpected = 0
     try:
         while time.monotonic() < deadline:
             time.sleep(max(1, interval))
@@ -711,11 +720,19 @@ def run_link(
             except SystemExit as exc:
                 if _is_terminal_poll_error(exc):
                     # Stop now with the server's explanation instead of spamming "retrying..."
-                    # until the deadline — a terminal 4xx returns the same response every poll.
+                    # until the deadline — a terminal 3xx/4xx returns the same response every poll.
                     print(f"\nLink failed: {exc}", file=sys.stderr)
                     return 1
-                # Transient (5xx / 408 / 429 / DNS blip / malformed body): keep polling until our
-                # monotonic deadline instead of aborting the whole flow.
+                # Transient (5xx / 408 / 429 / DNS blip / malformed body): keep polling, but give up
+                # if it never recovers so a consistently broken response can't burn the full window.
+                consecutive_unexpected += 1
+                if consecutive_unexpected >= _MAX_CONSECUTIVE_POLL_FAILURES:
+                    print(
+                        f"\nLink failed: {consecutive_unexpected} consecutive poll errors "
+                        f"(last: {exc}); giving up.",
+                        file=sys.stderr,
+                    )
+                    return 1
                 print(f"  (poll error: {exc}; retrying...)", file=sys.stderr)
                 continue
             status = poll.get("status")
@@ -747,6 +764,26 @@ def run_link(
             if status == "expired":
                 print("\nLink request expired before approval.", file=sys.stderr)
                 return 1
+            if status in _POLL_PENDING_STATUSES:
+                # Explicit "keep waiting" status (forge-v2 returns authorization_pending): the flow
+                # is healthy, so reset the non-progress counter and poll again.
+                consecutive_unexpected = 0
+                continue
+            # Unrecognized status (a typo, a {"status":"error"} body, or a client/server version
+            # skew): don't poll silently. Count it toward the same bound so a server stuck on an
+            # unknown status fails fast instead of at the deadline.
+            consecutive_unexpected += 1
+            if consecutive_unexpected >= _MAX_CONSECUTIVE_POLL_FAILURES:
+                print(
+                    f"\nLink failed: server returned an unrecognized poll status "
+                    f"{_printable(str(status))!r} {consecutive_unexpected} times; giving up.",
+                    file=sys.stderr,
+                )
+                return 1
+            print(
+                f"  (unexpected poll status {_printable(str(status))!r}; retrying...)",
+                file=sys.stderr,
+            )
     finally:
         poller.close()
 

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -29,7 +29,7 @@ import urllib.error
 import urllib.request
 import webbrowser
 from pathlib import Path
-from typing import Any, Optional, TypedDict
+from typing import Any, TypedDict
 from urllib.parse import urlparse
 
 DEFAULT_FORGE_URL = "https://forge.allora.network"
@@ -129,17 +129,18 @@ def discover_keys(secrets_path: str | Path) -> dict[str, _KeyEntry]:
         print(f"could not read worker secrets at {secrets_path}: {exc}", file=sys.stderr)
         return {}
     base = os.path.dirname(os.path.abspath(path))
-    out: dict[str, _KeyEntry] = {}
-    for alias, entry in raw.items():
-        if isinstance(entry, dict) and entry.get("address") and entry.get("key_file"):
-            out[entry["address"]] = {
-                "alias": alias,
-                "key_file": _checked_key_file(base, entry["address"], entry["key_file"]),
-            }
-    return out
+    return {
+        entry["address"]: {
+            "alias": alias,
+            "key_file": _checked_key_file(base, entry["address"], entry["key_file"]),
+        }
+        for alias, entry in raw.items()
+        if isinstance(entry, dict) and entry.get("address") and entry.get("key_file")
+    }
 
 
 def _post_json(url: str, payload: dict[str, Any], timeout: float = 15.0) -> dict[str, Any]:
+    """POST JSON payload to url; raises SystemExit on HTTP/network errors."""
     body = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(
         url, data=body, headers={"Content-Type": "application/json"}, method="POST"
@@ -162,7 +163,7 @@ def _printable(text: str) -> str:
 def run_link(
     forge_url: str = DEFAULT_FORGE_URL,
     secrets_path: str = DEFAULT_SECRETS_PATH,
-    addresses: Optional[list[str]] = None,
+    addresses: list[str] | None = None,
     open_browser: bool = True,
     insecure: bool = False,
 ) -> int:
@@ -315,7 +316,7 @@ def run_link(
     return 1
 
 
-def main(argv: Optional[list[str]] = None) -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="allora-forge-link",
         description="Prove ownership of local worker wallets and link them to Allora Forge.",

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -123,6 +123,11 @@ def _post_json(url: str, payload: dict[str, Any], timeout: float = 15.0) -> dict
         raise SystemExit(f"could not reach {url}: {exc.reason}") from exc
 
 
+def _printable(text: str) -> str:
+    """Drop non-printable chars so server strings can't inject terminal escapes."""
+    return "".join(c for c in text if c.isprintable())
+
+
 def run_link(
     forge_url: str = DEFAULT_FORGE_URL,
     secrets_path: str = DEFAULT_SECRETS_PATH,
@@ -233,8 +238,8 @@ def run_link(
 
     # 3. Hand off to the browser for the logged-in user to approve.
     print()
-    print(f"  First copy your one-time code: {user_code}")
-    print(f"  Then approve the link at: {verification_uri_complete}")
+    print(f"  First copy your one-time code: {_printable(user_code)}")
+    print(f"  Then approve the link at: {_printable(verification_uri_complete)}")
     print()
     if open_browser:
         try:

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -145,7 +145,11 @@ def run_link(
     device_code = start["device_code"]
     user_code = start["user_code"]
     verification_uri_complete = start["verification_uri_complete"]
-    interval = int(start.get("interval", 5))
+    try:
+        interval = int(start.get("interval", 5))
+    except (TypeError, ValueError):
+        interval = 5
+    interval = max(1, min(interval, 60))
     challenges = {c["address"]: c["message"] for c in start.get("challenges", [])}
 
     # 2. Sign each challenge locally and submit the signatures.

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import base64
 import json
+import re
 import sys
 import time
 import urllib.error
@@ -47,6 +48,10 @@ def build_adr036_sign_doc(signer: str, message: str) -> bytes:
     Must match the Go verifier and Keplr byte-for-byte: keys sorted alphabetically
     at every level, no whitespace, ``data`` = standard-base64 of the raw message.
     """
+    # signer is concatenated unescaped; restrict it to the bech32 grammar so a
+    # stray quote/backslash/control byte can't corrupt or inject into the JSON.
+    if not re.fullmatch(r"[a-z0-9]+", signer):
+        raise ValueError(f"invalid bech32 signer: {signer!r}")
     data = base64.standard_b64encode(message.encode("utf-8")).decode("ascii")
     return (
         '{"account_number":"0","chain_id":"","fee":{"amount":[],"gas":"0"},'

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -65,10 +65,13 @@ def build_adr036_sign_doc(signer: str, message: str) -> bytes:
     Must match the Go verifier and Keplr byte-for-byte: keys sorted alphabetically
     at every level, no whitespace, ``data`` = standard-base64 of the raw message.
     """
-    # signer is concatenated unescaped; restrict it to the bech32 grammar so a
-    # stray quote/backslash/control byte can't corrupt or inject into the JSON.
+    # signer is concatenated unescaped; restrict it to lowercase ASCII alphanumerics so a stray
+    # quote/backslash/control byte can't corrupt or inject into the JSON. This is an injection
+    # guard, NOT bech32 validation (r"[a-z0-9]+" accepts "alloabc" with no separator); full bech32
+    # structure (HRP + "1" separator + checksummed data) is enforced upstream by cosmpy's
+    # LocalWallet.from_mnemonic, whose derived address must equal this signer.
     if not re.fullmatch(r"[a-z0-9]+", signer):
-        raise ValueError(f"invalid bech32 signer: {signer!r}")
+        raise ValueError(f"invalid signer (must be lowercase alphanumeric): {signer!r}")
     data = base64.standard_b64encode(message.encode("utf-8")).decode("ascii")
     return (
         '{"account_number":"0","chain_id":"","fee":{"amount":[],"gas":"0"},'
@@ -158,11 +161,20 @@ class SecretsLoadError(Exception):
 
 
 def discover_keys(secrets_path: str | Path) -> dict[str, _KeyEntry]:
-    """Load WorkerManager secrets: {address: {"alias", "key_file"}}.
+    """Load WorkerManager worker keys from the secrets file.
 
-    Returns an empty mapping when the file is absent. Raises :class:`SecretsLoadError` when a
-    present file is unreadable, not valid JSON, or not a JSON object, so a corrupt secrets file is
-    not masked as "no keys".
+    Args:
+        secrets_path: Path to the WorkerManager ``worker_secrets.json`` file.
+
+    Returns:
+        A mapping ``{address: {"alias", "key_file"}}`` of every valid local key. It is empty in two
+        distinct cases: the file is absent (no workers created yet), or the file is present but
+        holds no valid ``{address, key_file}`` entries (malformed entries are skipped with a stderr
+        warning). A duplicate address keeps the last alias, also with a warning.
+
+    Raises:
+        SecretsLoadError: The file is present but unreadable, not valid JSON, or not a JSON object —
+            surfaced instead of being masked as the misleading "no keys" case.
     """
     path = Path(secrets_path)
     if not path.exists():
@@ -857,6 +869,14 @@ def add_link_arguments(
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Parse CLI arguments and run the device-flow wallet-link (``allora-forge-link`` entry point).
+
+    Args:
+        argv: Argument list to parse; ``None`` uses ``sys.argv`` (pass a list in tests).
+
+    Returns:
+        Process exit code from :func:`run_link` (0 on success, 1 on error).
+    """
     parser = argparse.ArgumentParser(
         prog="allora-forge-link",
         description=(

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -96,7 +96,10 @@ def discover_keys(secrets_path: str | Path) -> dict[str, _KeyEntry]:
         return {}
     try:
         raw = json.loads(path.read_text())
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, OSError) as exc:
+        # Present-but-unreadable/corrupt is distinct from not-found: surface it
+        # instead of masking it as the "no worker keys, create one" case.
+        print(f"could not read worker secrets at {secrets_path}: {exc}", file=sys.stderr)
         return {}
     out: dict[str, _KeyEntry] = {}
     for alias, entry in raw.items():

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -74,6 +74,16 @@ def build_adr036_sign_doc(signer: str, message: str) -> bytes:
     ).encode("utf-8")
 
 
+class WalletSignError(ValueError):
+    """A signing failure whose message is guaranteed free of key material.
+
+    Subclasses ``ValueError`` for backward compatibility. Raised only for failures whose message is
+    known to contain no mnemonic bytes (e.g. a derived-address mismatch), so ``run_link`` can echo
+    it verbatim while treating every *other* signing exception as opaque (type name only) to keep
+    private key material out of stderr and logs.
+    """
+
+
 def sign_challenge(mnemonic: str, address: str, message: str) -> tuple[str, str]:
     """Sign an ADR-036 challenge with the mnemonic's key.
 
@@ -93,7 +103,9 @@ def sign_challenge(mnemonic: str, address: str, message: str) -> tuple[str, str]
     wallet = LocalWallet.from_mnemonic(mnemonic, "allo")
     derived = str(wallet.address())
     if derived != address:
-        raise ValueError(
+        # WalletSignError (not a bare ValueError): its message holds only bech32 addresses, so the
+        # caller may show it verbatim, unlike a cosmpy exception that could embed mnemonic bytes.
+        raise WalletSignError(
             f"key derives address {derived}, which does not match requested {address}"
         )
 
@@ -554,10 +566,33 @@ def run_link(
             print(f"Server returned no challenge for {address}", file=sys.stderr)
             return 1
         try:
-            mnemonic = Path(keys[address]["key_file"]).read_text().strip()
+            # utf-8 (not the platform default) so a BOM/exotic-locale key file fails with a clear
+            # UnicodeDecodeError here rather than a confusing downstream error.
+            mnemonic = Path(keys[address]["key_file"]).read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            # OSError messages describe the file (path/permissions), never key material.
+            print(f"failed to read key file for {address}: {exc}", file=sys.stderr)
+            return 1
+        if not mnemonic:
+            # Catch this before cosmpy, which would otherwise raise a confusing internal error.
+            print(f"key file for {address} is empty: {keys[address]['key_file']}", file=sys.stderr)
+            return 1
+        try:
             pubkey_b64, signature_b64 = sign_challenge(mnemonic, address, message)
-        except (ValueError, OSError) as exc:
+        except WalletSignError as exc:
+            # Raised by sign_challenge only with a key-material-free message (e.g. address mismatch).
             print(f"failed to sign challenge for {address}: {exc}", file=sys.stderr)
+            return 1
+        except Exception as exc:
+            # Any other signing/derivation failure (cosmpy ValueError, Bip39/secp256k1 errors, a bad
+            # UTF-8 mnemonic, ...) can embed mnemonic fragments in its message or args, so surface
+            # only the exception *type* — never str(exc) — keeping key material out of stderr/logs.
+            print(
+                f"failed to sign challenge for {address}: {type(exc).__name__} "
+                "(detail withheld to avoid leaking key material; ensure the key file holds a "
+                "valid BIP-39 mnemonic for this address)",
+                file=sys.stderr,
+            )
             return 1
         signatures.append(
             {"address": address, "pubkey": pubkey_b64, "signature": signature_b64}

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -727,6 +727,10 @@ def run_link(
     except (TypeError, ValueError):
         timeout = _POLL_TIMEOUT_SECONDS
     timeout = max(1, min(timeout, _POLL_TIMEOUT_SECONDS))
+    # Clamp the interval to the deadline so at least one poll fires within the window even for a
+    # pathological server response (e.g. expires_in=1 + interval=60), which would otherwise sleep
+    # clean past the deadline. interval stays >= 1, so the sleep below needs no floor.
+    interval = min(interval, max(1, timeout // 2))
     # Monotonic deadline: immune to NTP steps / manual clock changes / DST that a wall-clock
     # time.time() deadline would let silently extend or prematurely abort the session.
     deadline = time.monotonic() + timeout
@@ -738,7 +742,8 @@ def run_link(
     consecutive_unexpected = 0
     try:
         while time.monotonic() < deadline:
-            time.sleep(max(1, interval))
+            # interval is already clamped to [1, timeout//2] above, so no inner max(1, ...) floor.
+            time.sleep(interval)
             try:
                 poll = poller.post(
                     f"{forge_url}/api/v1/wallet-link/device/poll", {"device_code": device_code}

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -1,0 +1,236 @@
+"""Link locally-managed worker wallets to a logged-in Allora Forge account.
+
+This is the default, ``gh auth login``-style flow for ENGN-8614: the CLI signs an
+ADR-036 challenge with the worker key on disk, opens the browser, the logged-in
+user approves, and the CLI polls to completion. The mnemonic never leaves the dev
+kit. Works headless too (it prints the URL + code to open on any device).
+
+Usage::
+
+    python -m allora_forge_builder_kit.wallet_link --forge-url https://forge.allora.network
+    # or a subset of addresses / a single one:
+    python -m allora_forge_builder_kit.wallet_link --address allo1... --address allo1...
+
+The signature contract (canonical amino ``sign/MsgSignData`` doc, sorted keys, no
+whitespace) MUST stay byte-for-byte identical to the Go verifier in
+``forge-v2/backend/internal/service/adr036.go`` and to Keplr's ``signArbitrary``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+import webbrowser
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_FORGE_URL = "https://forge.allora.network"
+DEFAULT_SECRETS_PATH = "worker_secrets.json"
+_POLL_TIMEOUT_SECONDS = 600
+
+
+def build_adr036_sign_doc(signer: str, message: str) -> bytes:
+    """Return the canonical Cosmos ADR-036 amino StdSignDoc bytes.
+
+    Must match the Go verifier and Keplr byte-for-byte: keys sorted alphabetically
+    at every level, no whitespace, ``data`` = standard-base64 of the raw message.
+    """
+    data = base64.standard_b64encode(message.encode("utf-8")).decode("ascii")
+    return (
+        '{"account_number":"0","chain_id":"","fee":{"amount":[],"gas":"0"},'
+        '"memo":"","msgs":[{"type":"sign/MsgSignData","value":{"data":"'
+        + data
+        + '","signer":"'
+        + signer
+        + '"}}],"sequence":"0"}'
+    ).encode("utf-8")
+
+
+def sign_challenge(mnemonic: str, address: str, message: str) -> tuple[str, str]:
+    """Sign an ADR-036 challenge with the mnemonic's key.
+
+    Returns ``(pubkey_b64, signature_b64)`` where pubkey is the 33-byte compressed
+    secp256k1 key and signature is the 64-byte compact (r||s) form, both
+    standard-base64. cosmpy's ``PrivateKey.sign`` signs ``sha256(doc)`` and returns
+    the canonical 64-byte signature, matching the server's verification.
+    """
+    try:
+        from cosmpy.aerial.wallet import LocalWallet
+    except ImportError as exc:  # pragma: no cover - environment guard
+        raise SystemExit(
+            "cosmpy is required to sign. Install the builder kit deps "
+            "(pip install -e . / cosmpy==0.11.1)."
+        ) from exc
+
+    wallet = LocalWallet.from_mnemonic(mnemonic, "allo")
+    derived = str(wallet.address())
+    if derived != address:
+        raise ValueError(
+            f"key derives address {derived}, which does not match requested {address}"
+        )
+
+    signer = wallet.signer()
+    doc = build_adr036_sign_doc(address, message)
+    signature = signer.sign(doc)
+    pubkey_b64 = base64.standard_b64encode(signer.public_key_bytes).decode("ascii")
+    signature_b64 = base64.standard_b64encode(signature).decode("ascii")
+    return pubkey_b64, signature_b64
+
+
+def discover_keys(secrets_path: str | Path) -> dict[str, dict]:
+    """Load WorkerManager secrets: {address: {"alias", "key_file"}}."""
+    path = Path(secrets_path)
+    if not path.exists():
+        return {}
+    try:
+        raw = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+    out: dict[str, dict] = {}
+    for alias, entry in raw.items():
+        if isinstance(entry, dict) and entry.get("address") and entry.get("key_file"):
+            out[entry["address"]] = {"alias": alias, "key_file": entry["key_file"]}
+    return out
+
+
+def _post_json(url: str, payload: dict, timeout: float = 15.0) -> dict:
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=body, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")
+        raise SystemExit(f"request to {url} failed ({exc.code}): {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"could not reach {url}: {exc.reason}") from exc
+
+
+def run_link(
+    forge_url: str = DEFAULT_FORGE_URL,
+    secrets_path: str = DEFAULT_SECRETS_PATH,
+    addresses: Optional[list[str]] = None,
+    open_browser: bool = True,
+) -> int:
+    """Drive the full device flow. Returns a process exit code."""
+    forge_url = forge_url.rstrip("/")
+    keys = discover_keys(secrets_path)
+    if not keys:
+        print(
+            f"No worker keys found in {secrets_path}. Create a worker first "
+            f"(e.g. via WorkerManager.deploy_worker).",
+            file=sys.stderr,
+        )
+        return 1
+
+    selected = addresses or list(keys.keys())
+    missing = [a for a in selected if a not in keys]
+    if missing:
+        print(f"No local key for: {', '.join(missing)}", file=sys.stderr)
+        return 1
+
+    print(f"Linking {len(selected)} worker address(es) to Allora Forge at {forge_url}")
+
+    # 1. Start the device session.
+    start = _post_json(
+        f"{forge_url}/api/v1/wallet-link/device/start", {"addresses": selected}
+    )
+    device_code = start["device_code"]
+    user_code = start["user_code"]
+    verification_uri_complete = start["verification_uri_complete"]
+    interval = int(start.get("interval", 5))
+    challenges = {c["address"]: c["message"] for c in start.get("challenges", [])}
+
+    # 2. Sign each challenge locally and submit the signatures.
+    signatures = []
+    for address in selected:
+        message = challenges.get(address)
+        if message is None:
+            print(f"Server returned no challenge for {address}", file=sys.stderr)
+            return 1
+        mnemonic = Path(keys[address]["key_file"]).read_text().strip()
+        pubkey_b64, signature_b64 = sign_challenge(mnemonic, address, message)
+        signatures.append(
+            {"address": address, "pubkey": pubkey_b64, "signature": signature_b64}
+        )
+
+    _post_json(
+        f"{forge_url}/api/v1/wallet-link/device/submit",
+        {"device_code": device_code, "signatures": signatures},
+    )
+
+    # 3. Hand off to the browser for the logged-in user to approve.
+    print()
+    print(f"  First copy your one-time code: {user_code}")
+    print(f"  Then approve the link at: {verification_uri_complete}")
+    print()
+    if open_browser:
+        try:
+            webbrowser.open(verification_uri_complete)
+            print("Opened your browser. Waiting for approval...")
+        except Exception:  # pragma: no cover - headless / no browser
+            print("Could not open a browser; open the URL above. Waiting...")
+    else:
+        print("Waiting for approval...")
+
+    # 4. Poll until the user approves/denies or the session expires.
+    deadline = time.time() + _POLL_TIMEOUT_SECONDS
+    while time.time() < deadline:
+        time.sleep(max(1, interval))
+        poll = _post_json(
+            f"{forge_url}/api/v1/wallet-link/device/poll", {"device_code": device_code}
+        )
+        status = poll.get("status")
+        if status == "approved":
+            linked = poll.get("linked", [])
+            print(f"\nLinked {len(linked)} verified worker(s):")
+            for addr in linked:
+                print(f"  + {addr}")
+            return 0
+        if status == "denied":
+            print("\nLink request was denied in the browser.", file=sys.stderr)
+            return 1
+        if status == "expired":
+            print("\nLink request expired before approval.", file=sys.stderr)
+            return 1
+
+    print("\nTimed out waiting for browser approval.", file=sys.stderr)
+    return 1
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="allora-forge-link",
+        description="Prove ownership of local worker wallets and link them to Allora Forge.",
+    )
+    parser.add_argument("--forge-url", default=DEFAULT_FORGE_URL, help="Forge base URL")
+    parser.add_argument(
+        "--secrets-path", default=DEFAULT_SECRETS_PATH, help="WorkerManager secrets file"
+    )
+    parser.add_argument(
+        "--address",
+        action="append",
+        dest="addresses",
+        help="Limit to specific allo1... address(es); repeatable. Default: all local keys.",
+    )
+    parser.add_argument(
+        "--no-browser", action="store_true", help="Do not auto-open a browser"
+    )
+    args = parser.parse_args(argv)
+    return run_link(
+        forge_url=args.forge_url,
+        secrets_path=args.secrets_path,
+        addresses=args.addresses,
+        open_browser=not args.no_browser,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -174,6 +174,22 @@ def run_link(
         if isinstance(c, dict) and c.get("address") and c.get("message")
     }
 
+    # Pin the server-returned approval URL to the forge origin and a safe
+    # scheme so a compromised server can't phish via a different host or hand
+    # a file://, javascript:, or app-launcher URI to the OS handler.
+    verification = urlparse(verification_uri_complete)
+    same_host = verification.hostname == parsed.hostname
+    safe_scheme = verification.scheme == "https" or (
+        verification.scheme == "http"
+        and (verification.hostname in ("localhost", "127.0.0.1") or insecure)
+    )
+    if not (same_host and safe_scheme):
+        print(
+            f"refusing to open untrusted verification URL: {verification_uri_complete}",
+            file=sys.stderr,
+        )
+        return 1
+
     # 2. Sign each challenge locally and submit the signatures.
     signatures = []
     for address in selected:

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -150,6 +150,16 @@ def run_link(
         print(f"No local key for: {', '.join(missing)}", file=sys.stderr)
         return 1
 
+    # Validate key files up front so a stale secrets entry fails before we
+    # open a server-side device session that would otherwise be orphaned.
+    unreadable = [a for a in selected if not Path(keys[a]["key_file"]).is_file()]
+    if unreadable:
+        print(
+            f"key file missing for: {', '.join(unreadable)} (stale {secrets_path}?)",
+            file=sys.stderr,
+        )
+        return 1
+
     print(f"Linking {len(selected)} worker address(es) to Allora Forge at {forge_url}")
 
     # 1. Start the device session.
@@ -197,8 +207,12 @@ def run_link(
         if message is None:
             print(f"Server returned no challenge for {address}", file=sys.stderr)
             return 1
-        mnemonic = Path(keys[address]["key_file"]).read_text().strip()
-        pubkey_b64, signature_b64 = sign_challenge(mnemonic, address, message)
+        try:
+            mnemonic = Path(keys[address]["key_file"]).read_text().strip()
+            pubkey_b64, signature_b64 = sign_challenge(mnemonic, address, message)
+        except (ValueError, OSError) as exc:
+            print(f"failed to sign challenge for {address}: {exc}", file=sys.stderr)
+            return 1
         signatures.append(
             {"address": address, "pubkey": pubkey_b64, "signature": signature_b64}
         )

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -501,7 +501,23 @@ def run_link(
     open_browser: bool = True,
     insecure: bool = False,
 ) -> int:
-    """Drive the full device flow. Returns a process exit code."""
+    """Drive the full device-flow wallet-link process.
+
+    Signs an ADR-036 challenge for each selected worker key on disk, opens the browser for the
+    logged-in Forge user to approve, and polls to completion. The mnemonic never leaves the machine.
+
+    Args:
+        forge_url: Base URL of the Allora Forge API (scheme + host, no path). Must be ``https://``
+            unless ``insecure`` is set or the host is loopback.
+        secrets_path: Path to the WorkerManager secrets file (``worker_secrets.json``).
+        addresses: Specific ``allo1...`` addresses to link. ``None`` links every local key
+            (duplicates removed); an explicit empty list is an error (links nothing), not "all".
+        open_browser: When True (default), auto-open the verification URL in the system browser.
+        insecure: Allow a plaintext ``http://`` forge URL (local dev only).
+
+    Returns:
+        Process exit code: 0 on success, 1 on any error.
+    """
     forge_url = forge_url.rstrip("/")
     parsed = urlparse(forge_url)
     if (
@@ -540,7 +556,17 @@ def run_link(
         )
         return 1
 
-    selected = addresses or list(keys.keys())
+    if addresses is None:
+        selected = list(keys.keys())
+    elif not addresses:
+        # Distinguish None (link all) from [] (explicit empty): an empty list must fail closed
+        # rather than fall through the old `or` idiom and silently link every local wallet.
+        print("no addresses specified (--address was given with an empty selection)", file=sys.stderr)
+        return 1
+    else:
+        # Dedup while preserving order: repeated `--address X --address X` would otherwise submit
+        # duplicate signatures and consume 2x the server's per-address rate-limit budget.
+        selected = list(dict.fromkeys(addresses))
     missing = [a for a in selected if a not in keys]
     if missing:
         # A managed-custody worker has no local key file, so it legitimately won't appear

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -822,6 +822,40 @@ def run_link(
     return 1
 
 
+def add_link_arguments(
+    parser: argparse.ArgumentParser, *, secrets_default: Any = DEFAULT_SECRETS_PATH
+) -> None:
+    """Register the shared wallet-link CLI flags on ``parser``.
+
+    Called by both the standalone ``allora-forge-link`` entry point and the ``workerctl link``
+    subcommand so the two flag surfaces can't drift out of sync.
+
+    Args:
+        parser: The (sub)parser to add ``--forge-url``, ``--secrets-path``, ``--address``,
+            ``--no-browser`` and ``--insecure`` to.
+        secrets_default: Default for ``--secrets-path``. ``workerctl`` passes
+            ``argparse.SUPPRESS`` so a subcommand-level flag doesn't clobber a top-level
+            ``--secrets-path`` given before the subcommand; the standalone entry point uses the
+            real default path.
+    """
+    parser.add_argument("--forge-url", default=DEFAULT_FORGE_URL, help="Forge base URL")
+    parser.add_argument(
+        "--secrets-path", default=secrets_default, help="WorkerManager secrets file"
+    )
+    parser.add_argument(
+        "--address",
+        action="append",
+        dest="addresses",
+        help="Limit to specific allo1... address(es); repeatable. Default: all local keys.",
+    )
+    parser.add_argument("--no-browser", action="store_true", help="Do not auto-open a browser")
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help="Allow a plaintext http:// forge URL (local dev only)",
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="allora-forge-link",
@@ -833,24 +867,7 @@ def main(argv: list[str] | None = None) -> int:
             "neither required nor handled here."
         ),
     )
-    parser.add_argument("--forge-url", default=DEFAULT_FORGE_URL, help="Forge base URL")
-    parser.add_argument(
-        "--secrets-path", default=DEFAULT_SECRETS_PATH, help="WorkerManager secrets file"
-    )
-    parser.add_argument(
-        "--address",
-        action="append",
-        dest="addresses",
-        help="Limit to specific allo1... address(es); repeatable. Default: all local keys.",
-    )
-    parser.add_argument(
-        "--no-browser", action="store_true", help="Do not auto-open a browser"
-    )
-    parser.add_argument(
-        "--insecure",
-        action="store_true",
-        help="Allow a plaintext http:// forge URL (local dev only)",
-    )
+    add_link_arguments(parser)
     args = parser.parse_args(argv)
     return run_link(
         forge_url=args.forge_url,

--- a/allora_forge_builder_kit/wallet_link.py
+++ b/allora_forge_builder_kit/wallet_link.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import http.client
 import json
 import os
 import re
@@ -30,12 +31,20 @@ import urllib.request
 import webbrowser
 from pathlib import Path
 from typing import Any, TypedDict
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse, urlsplit
 
 DEFAULT_FORGE_URL = "https://forge.allora.network"
 DEFAULT_SECRETS_PATH = "worker_secrets.json"
-_POLL_TIMEOUT_SECONDS = 600
+# Ceiling on how long the device-flow poll loop waits for browser approval. The client honors the
+# server-advertised expires_in but clamps it to this bound (with a 1s floor). Sized to the typical
+# RFC 8628 device-authorization session window (900-1800s); a lower ceiling would abort sessions the
+# server still considers live (e.g. an approval delayed by MFA or a device switch).
+_POLL_TIMEOUT_SECONDS = 1800
 _MAX_RESPONSE_BYTES = 512 * 1024
+# Loopback hosts treated as safe for plaintext HTTP / verification-URL origin pinning. Includes the
+# IPv6 loopback ::1 (urlparse('http://[::1]/').hostname == '::1', no brackets) so a local Forge bound
+# to [::1] on a dual-stack host doesn't require --insecure.
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 
 
 # A single discovered worker key entry from worker_secrets.json.
@@ -97,7 +106,12 @@ def sign_challenge(mnemonic: str, address: str, message: str) -> tuple[str, str]
 
 
 def _checked_key_file(base: str, address: str, key_file: str) -> str:
-    """Warn (without rejecting) when a secrets key_file resolves outside the secrets dir."""
+    """Resolve a secrets key_file against the secrets dir, warning when it escapes that dir.
+
+    Returns the absolute path so a relative key_file is read against the secrets file's location
+    (not the caller's cwd); without this, a non-default ``--secrets-path`` would make wallet-link
+    read/check the wrong key file.
+    """
     kf = Path(key_file).expanduser()
     kf_abs = os.path.abspath(kf if kf.is_absolute() else Path(base) / kf)
     try:
@@ -113,51 +127,305 @@ def _checked_key_file(base: str, address: str, key_file: str) -> str:
             f"{base}; reading it anyway ({key_file})",
             file=sys.stderr,
         )
-    return key_file
+    return kf_abs
+
+
+class SecretsLoadError(Exception):
+    """Raised when a present worker-secrets file cannot be read or parsed.
+
+    Distinct from an *absent* secrets file (which :func:`discover_keys` reports as no keys) so a
+    caller can surface a corrupt/unreadable file instead of the misleading "no worker keys, create
+    one" path.
+    """
 
 
 def discover_keys(secrets_path: str | Path) -> dict[str, _KeyEntry]:
-    """Load WorkerManager secrets: {address: {"alias", "key_file"}}."""
+    """Load WorkerManager secrets: {address: {"alias", "key_file"}}.
+
+    Returns an empty mapping when the file is absent. Raises :class:`SecretsLoadError` when a
+    present file is unreadable, not valid JSON, or not a JSON object, so a corrupt secrets file is
+    not masked as "no keys".
+    """
     path = Path(secrets_path)
     if not path.exists():
         return {}
     try:
         raw = json.loads(path.read_text())
     except (json.JSONDecodeError, OSError) as exc:
-        # Present-but-unreadable/corrupt is distinct from not-found: surface it
-        # instead of masking it as the "no worker keys, create one" case.
-        print(f"could not read worker secrets at {secrets_path}: {exc}", file=sys.stderr)
-        return {}
+        # Present-but-unreadable/corrupt is distinct from not-found: surface it instead of
+        # masking it as the "no worker keys, create one" case.
+        raise SecretsLoadError(f"could not read worker secrets at {secrets_path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        # Valid JSON whose root is a list/scalar would crash on raw.items(); a malformed-but-
+        # parseable secrets file is a corrupt file, not "no keys".
+        raise SecretsLoadError(f"worker secrets at {secrets_path} is not a JSON object")
     base = os.path.dirname(os.path.abspath(path))
-    return {
-        entry["address"]: {
+    # Keyed by address; warn (rather than silently overwrite) when two aliases share an address,
+    # since the second would otherwise win invisibly — a footgun combined with relative key_files.
+    keys: dict[str, _KeyEntry] = {}
+    for alias, entry in raw.items():
+        if not isinstance(entry, dict):
+            continue
+        address = entry.get("address")
+        key_file = entry.get("key_file")
+        # Require strings (not just truthy): a tampered secrets file with non-string values
+        # (e.g. {"address": 123}) would otherwise reach _checked_key_file and crash on
+        # Path(123), defeating the documented "warn, skip" handling for a malformed file.
+        if not (isinstance(address, str) and address and isinstance(key_file, str) and key_file):
+            continue
+        if address in keys:
+            print(
+                f"warning: duplicate address {address} in {secrets_path}; "
+                f"alias {alias!r} overrides {keys[address]['alias']!r}",
+                file=sys.stderr,
+            )
+        keys[address] = {
             "alias": alias,
-            "key_file": _checked_key_file(base, entry["address"], entry["key_file"]),
+            "key_file": _checked_key_file(base, address, key_file),
         }
-        for alias, entry in raw.items()
-        if isinstance(entry, dict) and entry.get("address") and entry.get("key_file")
-    }
+    return keys
+
+
+class _RequestError(SystemExit):
+    """A wallet-link HTTP/network failure.
+
+    Subclasses ``SystemExit`` so an unhandled error still aborts the CLI with a clean message
+    (no traceback), like the rest of this module, while carrying the HTTP ``status`` (``None`` for
+    network/transport errors) so the device-flow poll loop can stop on a terminal 4xx instead of
+    retrying it until the deadline.
+    """
+
+    def __init__(self, message: str, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+def _is_terminal_poll_error(exc: BaseException) -> bool:
+    """True when a poll error should stop the device flow immediately rather than be retried.
+
+    Terminal = a 4xx client error other than 408/429 (e.g. the device code is expired, invalid, or
+    already used): every retry returns the same response until the deadline. 5xx, 408, 429, network
+    blips, and malformed-body errors (no ``status``) are transient and keep polling.
+    """
+    status = getattr(exc, "status", None)
+    return status is not None and 400 <= status < 500 and status not in (408, 429)
+
+
+def _loads_json_object(url: str, raw: str) -> dict[str, Any]:
+    """Parse a server response body into a JSON object.
+
+    Raises ``SystemExit`` when the body is not valid JSON, or is valid JSON that is not an object
+    (a list, string, number, or null), so callers never hit an ``AttributeError`` from ``.get(...)``
+    on a non-dict nor an unwrapped ``JSONDecodeError``. On the poll path this ``SystemExit`` is
+    caught and retried as transient; on start/submit it aborts cleanly like the HTTP-error path.
+    """
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"request to {url} returned non-JSON: {raw[:200]!r}") from exc
+    if not isinstance(parsed, dict):
+        raise SystemExit(f"request to {url} returned unexpected JSON type: {type(parsed).__name__}")
+    return parsed
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Refuse to follow redirects so a 3xx surfaces as an HTTPError.
+
+    A signed wallet-link POST body must never be replayed to a redirect target: returning None
+    from redirect_request makes urllib raise instead of re-issuing the request elsewhere. (The
+    keep-alive ``_JsonPoster`` path uses ``http.client`` directly and never redirects either.)
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: D102
+        return None
+
+
+# Opener without redirect following, used for the (non-keep-alive) start/submit POSTs.
+_OPENER = urllib.request.build_opener(_NoRedirectHandler)
 
 
 def _post_json(url: str, payload: dict[str, Any], timeout: float = 15.0) -> dict[str, Any]:
-    """POST JSON payload to url; raises SystemExit on HTTP/network errors."""
+    """POST JSON payload to url; raises SystemExit on HTTP/network errors or a non-object body."""
     body = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(
         url, data=body, headers={"Content-Type": "application/json"}, method="POST"
     )
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return json.loads(resp.read(_MAX_RESPONSE_BYTES).decode("utf-8"))
+        with _OPENER.open(req, timeout=timeout) as resp:
+            return _loads_json_object(url, resp.read(_MAX_RESPONSE_BYTES).decode("utf-8", "replace"))
     except urllib.error.HTTPError as exc:
-        detail = exc.read(_MAX_RESPONSE_BYTES).decode("utf-8", "replace")
-        raise SystemExit(f"request to {url} failed ({exc.code}): {detail}") from exc
+        # Filter the server-supplied error body so it can't inject terminal escapes (matches the
+        # _printable() treatment of user_code / verification_uri_complete on the success path).
+        detail = _printable(exc.read(_MAX_RESPONSE_BYTES).decode("utf-8", "replace"))
+        raise _RequestError(f"request to {url} failed ({exc.code}): {detail}", status=exc.code) from exc
     except urllib.error.URLError as exc:
-        raise SystemExit(f"could not reach {url}: {exc.reason}") from exc
+        raise _RequestError(f"could not reach {url}: {exc.reason}") from exc
 
 
 def _printable(text: str) -> str:
     """Drop non-printable chars so server strings can't inject terminal escapes."""
     return "".join(c for c in text if c.isprintable())
+
+
+def _default_port(scheme: str) -> int | None:
+    """Return the default TCP port for an URL scheme (so an unspecified port compares equal)."""
+    return {"https": 443, "http": 80}.get(scheme)
+
+
+def _submit_rejection(submit: dict[str, Any]) -> str | None:
+    """Return a user-facing message if /device/submit reported rejected signatures, else None.
+
+    The server can return HTTP 200 while rejecting individual signatures (e.g.
+    ``{"rejected": [{"address": "allo1...", "reason": "..."}]}``) or signalling a top-level
+    ``error``. Surfacing it
+    here lets the caller bail before the poll loop instead of waiting out the full deadline only to
+    report ``Linked 0 worker(s)``. Server strings are filtered through ``_printable``.
+    """
+    rejected = submit.get("rejected")
+    if isinstance(rejected, list) and rejected:
+        lines = ["Server rejected one or more worker signatures:"]
+        for item in rejected:
+            if not isinstance(item, dict):
+                continue
+            addr = _printable(str(item.get("address", "?")))
+            reason = _printable(str(item.get("reason", "no reason given")))
+            lines.append(f"  - {addr}: {reason}")
+        return "\n".join(lines)
+    error = submit.get("error")
+    if error:
+        return f"Server rejected the signature submission: {_printable(str(error))}"
+    return None
+
+
+# @@TODO: This module hand-rolls an HTTP transport (_post_json + _JsonPoster: proxy resolution,
+# CONNECT tunneling, Proxy-Authorization, keep-alive reconnect, bounded read) that duplicates the
+# requests.Session transport allora-sdk-py's ForgeBackendClient already owns for the same Forge
+# host. Consolidate by moving the device-flow transport into allora-sdk-py (e.g. a DeviceFlowClient
+# reusing the SDK Session) so builder-kit keeps only the CLI orchestration + ADR-036 sign-doc
+# builder. Cross-repo (allora-sdk-py + forge-v2); tracked as a follow-up, not done here.
+class _JsonPoster:
+    """Reusable JSON poster that holds one keep-alive connection to a fixed host.
+
+    The device-flow poll loop hits a single Forge host up to ~120 times; ``urllib`` opens a
+    fresh TCP+TLS connection per call, so reusing one connection removes a handshake per poll.
+    This mirrors ``_post_json``'s bounded read, error sanitization, ``SystemExit``-on-failure, and
+    proxy resolution (HTTP(S)_PROXY / NO_PROXY, including ``user:pass@`` proxy credentials sent as
+    ``Proxy-Authorization``) so the poll loop's existing transient-error handling and proxied
+    environments both keep working. A server that closed an idle keep-alive connection between polls
+    is handled by one transparent reconnect.
+    """
+
+    def __init__(self, base_url: str, timeout: float = 15.0) -> None:
+        parts = urlsplit(base_url)
+        self._host = parts.hostname or ""
+        self._port = parts.port
+        self._https = parts.scheme != "http"
+        self._timeout = timeout
+        self._conn: http.client.HTTPConnection | None = None
+        # http.client does not read proxy env vars, so resolve the proxy the way urllib (used by
+        # _post_json for /start and /submit) does. Without this the keep-alive poll connection
+        # would silently go direct and hang/fail behind a corporate HTTP(S) proxy.
+        proxy = self._select_proxy(base_url, self._https)
+        self._proxy: tuple[str, int | None] | None = (proxy[0], proxy[1]) if proxy is not None else None
+        # Pre-built "Basic <base64>" Proxy-Authorization value when the proxy URL carried userinfo,
+        # else None — without it an authenticated proxy answers every poll with 407.
+        self._proxy_auth: str | None = proxy[2] if proxy is not None else None
+
+    @staticmethod
+    def _select_proxy(base_url: str, https: bool) -> tuple[str, int | None, str | None] | None:
+        """Resolve the proxy for base_url from the environment as ``(host, port, auth)``.
+
+        Returns None for a direct connection, including when the host matches NO_PROXY. ``auth`` is
+        a ready ``Proxy-Authorization`` header value (``Basic <base64>``) when the proxy URL carries
+        userinfo, else None. Mirrors urllib's resolution (``getproxies`` + ``proxy_bypass``) so the
+        poll path honors the same proxy configuration — credentials included — as the urllib-based
+        start/submit requests.
+        """
+        host = urlsplit(base_url).hostname or ""
+        if urllib.request.proxy_bypass(host):
+            return None
+        proxies = urllib.request.getproxies()
+        proxy_url = proxies.get("https" if https else "http") or proxies.get("all")
+        if not proxy_url:
+            return None
+        parsed = urlsplit(proxy_url if "://" in proxy_url else f"//{proxy_url}", scheme="http")
+        if not parsed.hostname:
+            return None
+        auth = None
+        if parsed.username is not None:
+            # URL-unquote the userinfo before base64 so percent-encoded credentials (e.g. p%40ss)
+            # decode to their literal bytes, matching how urllib builds Proxy-Authorization.
+            user = unquote(parsed.username)
+            password = unquote(parsed.password) if parsed.password is not None else ""
+            token = base64.b64encode(f"{user}:{password}".encode("utf-8")).decode("ascii")
+            auth = f"Basic {token}"
+        if parsed.port is None:
+            # http.client silently defaults a missing port to 443 (HTTPS) / 80 (HTTP); an operator
+            # who set HTTPS_PROXY=proxy.corp.local expecting 3128/8080 would otherwise hit a
+            # confusing connection failure. Surface the implicit default.
+            print(
+                f"warning: proxy {parsed.hostname} has no explicit port; defaulting to "
+                f"{443 if https else 80}",
+                file=sys.stderr,
+            )
+        return (parsed.hostname, parsed.port, auth)
+
+    def _connect(self) -> http.client.HTTPConnection:
+        if self._proxy is not None:
+            proxy_host, proxy_port = self._proxy
+            if self._https:
+                # CONNECT-tunnel the TLS session through the proxy so the certificate is still
+                # validated against the real Forge host rather than the proxy. Proxy credentials
+                # (if any) ride on the CONNECT request itself via set_tunnel's headers.
+                conn = http.client.HTTPSConnection(proxy_host, proxy_port, timeout=self._timeout)
+                tunnel_headers = {"Proxy-Authorization": self._proxy_auth} if self._proxy_auth else {}
+                conn.set_tunnel(self._host, self._port, headers=tunnel_headers)
+                return conn
+            return http.client.HTTPConnection(proxy_host, proxy_port, timeout=self._timeout)
+        if self._https:
+            return http.client.HTTPSConnection(self._host, self._port, timeout=self._timeout)
+        return http.client.HTTPConnection(self._host, self._port, timeout=self._timeout)
+
+    def post(self, url: str, payload: dict[str, Any]) -> dict[str, Any]:
+        """POST JSON to url over the held connection; raises SystemExit on HTTP/network errors."""
+        # Through a plain-HTTP proxy the request line must carry the absolute URL (RFC 7230 5.3.2);
+        # direct and HTTPS-tunneled connections use the origin-form path.
+        if self._proxy is not None and not self._https:
+            request_target = url
+        else:
+            request_target = urlsplit(url).path or "/"
+        body = json.dumps(payload).encode("utf-8")
+        headers = {"Content-Type": "application/json"}
+        # Plain-HTTP proxy: auth rides the request; HTTPS auth already rode the CONNECT tunnel.
+        if self._proxy is not None and not self._https and self._proxy_auth:
+            headers["Proxy-Authorization"] = self._proxy_auth
+        # Retry once: the server may have dropped an idle keep-alive connection between polls.
+        for attempt in (1, 2):
+            if self._conn is None:
+                self._conn = self._connect()
+            try:
+                self._conn.request("POST", request_target, body=body, headers=headers)
+                resp = self._conn.getresponse()
+                data = resp.read(_MAX_RESPONSE_BYTES)
+                if resp.status >= 400:
+                    detail = _printable(data.decode("utf-8", "replace"))
+                    # Close before raising: _RequestError (a BaseException) escapes the except below,
+                    # so an undrained connection would defeat keep-alive.
+                    self.close()
+                    raise _RequestError(f"request to {url} failed ({resp.status}): {detail}", status=resp.status)
+                return _loads_json_object(url, data.decode("utf-8", "replace"))
+            except (http.client.HTTPException, OSError) as exc:
+                self.close()
+                if attempt == 2:
+                    raise _RequestError(f"could not reach {url}: {exc}") from exc
+        raise _RequestError(f"could not reach {url}")  # unreachable: the loop returns or raises
+
+    def close(self) -> None:
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            finally:
+                self._conn = None
 
 
 def run_link(
@@ -172,7 +440,7 @@ def run_link(
     parsed = urlparse(forge_url)
     if (
         parsed.scheme != "https"
-        and parsed.hostname not in ("localhost", "127.0.0.1")
+        and parsed.hostname not in _LOOPBACK_HOSTS
         and not insecure
     ):
         print(
@@ -181,7 +449,23 @@ def run_link(
             file=sys.stderr,
         )
         return 1
-    keys = discover_keys(secrets_path)
+    if parsed.path and parsed.path != "/":
+        # The /api/v1/wallet-link/... prefix is appended below, so a forge-url carrying a path
+        # (e.g. https://forge.allora.network/api/v1) would produce a double /api/v1 and a confusing
+        # 404. Reject it up front with an actionable message instead.
+        print(
+            f"forge_url must be a scheme+host with no path; got path={parsed.path!r}. "
+            "Use e.g. https://forge.allora.network (the /api/v1 prefix is added automatically).",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        keys = discover_keys(secrets_path)
+    except SecretsLoadError as exc:
+        # A corrupt / unreadable secrets file is a distinct failure from "no keys yet"; report it
+        # instead of the misleading "create a worker first" hint.
+        print(str(exc), file=sys.stderr)
+        return 1
     if not keys:
         print(
             f"No worker keys found in {secrets_path}. Create a worker first "
@@ -193,7 +477,15 @@ def run_link(
     selected = addresses or list(keys.keys())
     missing = [a for a in selected if a not in keys]
     if missing:
-        print(f"No local key for: {', '.join(missing)}", file=sys.stderr)
+        # A managed-custody worker has no local key file, so it legitimately won't appear
+        # here. Spell that out rather than leave the operator thinking a valid worker is
+        # broken: managed workers are linked automatically via the backend, not via this CLI.
+        print(
+            f"No local key for: {', '.join(missing)}\n"
+            "  (this command links LOCAL-custody workers only; a managed-custody worker is "
+            "linked automatically by the Forge backend and needs no local signing)",
+            file=sys.stderr,
+        )
         return 1
 
     # Validate key files up front so a stale secrets entry fails before we
@@ -213,8 +505,11 @@ def run_link(
         f"{forge_url}/api/v1/wallet-link/device/start", {"addresses": selected}
     )
     for field in ("device_code", "user_code", "verification_uri_complete"):
-        if not start.get(field):
-            print(f"server response missing required field: {field}", file=sys.stderr)
+        value = start.get(field)
+        # Require a non-empty string, not just truthiness: a non-string (e.g. an int from an
+        # over-eager JSON marshaler) would later crash urlparse()/_printable() with a raw traceback.
+        if not value or not isinstance(value, str):
+            print(f"server response missing or malformed required field: {field}", file=sys.stderr)
             return 1
     device_code = start["device_code"]
     user_code = start["user_code"]
@@ -235,11 +530,16 @@ def run_link(
     # a file://, javascript:, or app-launcher URI to the OS handler.
     verification = urlparse(verification_uri_complete)
     same_host = verification.hostname == parsed.hostname
+    # The port is part of the origin: pin it too (using the scheme default when unspecified) so a
+    # compromised server can't redirect to an arbitrary port on the same host.
+    same_port = (verification.port or _default_port(verification.scheme)) == (
+        parsed.port or _default_port(parsed.scheme)
+    )
     safe_scheme = verification.scheme == "https" or (
         verification.scheme == "http"
-        and (verification.hostname in ("localhost", "127.0.0.1") or insecure)
+        and (verification.hostname in _LOOPBACK_HOSTS or insecure)
     )
-    if not (same_host and safe_scheme):
+    if not (same_host and same_port and safe_scheme):
         print(
             f"refusing to open untrusted verification URL: {verification_uri_complete}",
             file=sys.stderr,
@@ -263,10 +563,14 @@ def run_link(
             {"address": address, "pubkey": pubkey_b64, "signature": signature_b64}
         )
 
-    _post_json(
+    submit = _post_json(
         f"{forge_url}/api/v1/wallet-link/device/submit",
         {"device_code": device_code, "signatures": signatures},
     )
+    rejection = _submit_rejection(submit)
+    if rejection is not None:
+        print(rejection, file=sys.stderr)
+        return 1
 
     # 3. Hand off to the browser for the logged-in user to approve.
     print()
@@ -293,31 +597,60 @@ def run_link(
     except (TypeError, ValueError):
         timeout = _POLL_TIMEOUT_SECONDS
     timeout = max(1, min(timeout, _POLL_TIMEOUT_SECONDS))
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        time.sleep(max(1, interval))
-        try:
-            poll = _post_json(
-                f"{forge_url}/api/v1/wallet-link/device/poll", {"device_code": device_code}
-            )
-        except SystemExit as exc:
-            # Transient HTTP/network error (502/503/429, DNS blip): keep polling
-            # until our wall-clock deadline instead of aborting the whole flow.
-            print(f"  (poll error: {exc}; retrying...)", file=sys.stderr)
-            continue
-        status = poll.get("status")
-        if status == "approved":
-            linked = poll.get("linked", [])
-            print(f"\nLinked {len(linked)} verified worker(s):")
-            for addr in linked:
-                print(f"  + {addr}")
-            return 0
-        if status == "denied":
-            print("\nLink request was denied in the browser.", file=sys.stderr)
-            return 1
-        if status == "expired":
-            print("\nLink request expired before approval.", file=sys.stderr)
-            return 1
+    # Monotonic deadline: immune to NTP steps / manual clock changes / DST that a wall-clock
+    # time.time() deadline would let silently extend or prematurely abort the session.
+    deadline = time.monotonic() + timeout
+    # Reuse one keep-alive connection across the (up to ~120) polls to the same Forge host
+    # instead of a fresh TCP+TLS handshake per poll.
+    poller = _JsonPoster(forge_url)
+    try:
+        while time.monotonic() < deadline:
+            time.sleep(max(1, interval))
+            try:
+                poll = poller.post(
+                    f"{forge_url}/api/v1/wallet-link/device/poll", {"device_code": device_code}
+                )
+            except SystemExit as exc:
+                if _is_terminal_poll_error(exc):
+                    # Stop now with the server's explanation instead of spamming "retrying..."
+                    # until the deadline — a terminal 4xx returns the same response every poll.
+                    print(f"\nLink failed: {exc}", file=sys.stderr)
+                    return 1
+                # Transient (5xx / 408 / 429 / DNS blip / malformed body): keep polling until our
+                # monotonic deadline instead of aborting the whole flow.
+                print(f"  (poll error: {exc}; retrying...)", file=sys.stderr)
+                continue
+            status = poll.get("status")
+            if status == "approved":
+                # Coerce defensively: a server emitting {"linked": null} would make
+                # poll.get("linked", []) return None (the key exists) and crash len(None).
+                linked_raw = poll.get("linked")
+                linked = linked_raw if isinstance(linked_raw, list) else []
+                # Server-controlled strings: filter terminal escapes so a malicious 'linked' entry
+                # can't render a clickable OSC-8 hyperlink disguised as a bech32 address.
+                linked_addrs = {a for a in linked if isinstance(a, str)}
+                missing = [a for a in selected if a not in linked_addrs]
+                if missing:
+                    # Approved but the backend linked only a subset (or none): a partial link is a
+                    # failure, not a silent exit 0 that signals success to a CI pipeline.
+                    print(
+                        f"\nLink reported approved but {len(missing)} requested address(es) "
+                        "were not linked:\n  " + "\n  ".join(_printable(a) for a in missing),
+                        file=sys.stderr,
+                    )
+                    return 1
+                print(f"\nLinked {len(linked_addrs)} verified worker(s):")
+                for addr in sorted(linked_addrs):
+                    print(f"  + {_printable(addr)}")
+                return 0
+            if status == "denied":
+                print("\nLink request was denied in the browser.", file=sys.stderr)
+                return 1
+            if status == "expired":
+                print("\nLink request expired before approval.", file=sys.stderr)
+                return 1
+    finally:
+        poller.close()
 
     print("\nTimed out waiting for browser approval.", file=sys.stderr)
     return 1
@@ -326,7 +659,13 @@ def run_link(
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="allora-forge-link",
-        description="Prove ownership of local worker wallets and link them to Allora Forge.",
+        description=(
+            "Prove ownership of LOCAL-custody worker wallets and link them to Allora Forge. "
+            "This command applies only to workers whose signing key lives in a local key file "
+            "(listed in the WorkerManager secrets file). Managed-custody workers are linked "
+            "automatically by the Forge backend, hold no local key to prove, and are therefore "
+            "neither required nor handled here."
+        ),
     )
     parser.add_argument("--forge-url", default=DEFAULT_FORGE_URL, help="Forge base URL")
     parser.add_argument(

--- a/allora_forge_builder_kit/workerctl.py
+++ b/allora_forge_builder_kit/workerctl.py
@@ -81,6 +81,8 @@ def main() -> None:
     p_link.add_argument("--address", action="append", dest="addresses",
                         help="Limit to specific allo1... address(es); repeatable. Default: all local keys.")
     p_link.add_argument("--no-browser", action="store_true", help="Do not auto-open a browser")
+    p_link.add_argument("--insecure", action="store_true",
+                        help="Allow a plaintext http:// forge URL (local dev only)")
 
     args = parser.parse_args()
     mgr_kwargs = dict(db_path=args.db_path, secrets_path=args.secrets_path, network=args.network)
@@ -95,6 +97,7 @@ def main() -> None:
             secrets_path=args.secrets_path,
             addresses=args.addresses,
             open_browser=not args.no_browser,
+            insecure=args.insecure,
         ))
 
     wm, _ = _make_manager(with_monitor=False, **mgr_kwargs)

--- a/allora_forge_builder_kit/workerctl.py
+++ b/allora_forge_builder_kit/workerctl.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 
 from .worker_manager import WorkerManager
 from .worker_monitor import WorkerMonitor, AlloraSDKEventFetcher
-from .wallet_link import DEFAULT_FORGE_URL, run_link
+from .wallet_link import add_link_arguments, run_link
 
 
 def _make_manager(
@@ -77,20 +77,10 @@ def main() -> None:
     sub.add_parser("stop-all", help="Stop running workers")
 
     p_link = sub.add_parser("link", help="Link local worker wallets to your Allora Forge account")
-    p_link.add_argument("--forge-url", default=DEFAULT_FORGE_URL, help="Forge base URL")
-    # SUPPRESS so the subcommand flag doesn't clobber a top-level --secrets-path
-    # given before the subcommand, while still appearing in `link --help`.
-    p_link.add_argument("--secrets-path", default=argparse.SUPPRESS,
-                        help="WorkerManager secrets file (default: worker_secrets.json)")
-    p_link.add_argument(
-        "--address",
-        action="append",
-        dest="addresses",
-        help="Limit to specific allo1... address(es); repeatable. Default: all local keys.",
-    )
-    p_link.add_argument("--no-browser", action="store_true", help="Do not auto-open a browser")
-    p_link.add_argument("--insecure", action="store_true",
-                        help="Allow a plaintext http:// forge URL (local dev only)")
+    # Shared flag definitions live in wallet_link.add_link_arguments so this subcommand and the
+    # standalone allora-forge-link entry point can't drift. SUPPRESS keeps a subcommand-level
+    # --secrets-path from clobbering a top-level --secrets-path given before the subcommand.
+    add_link_arguments(p_link, secrets_default=argparse.SUPPRESS)
 
     args = parser.parse_args()
     mgr_kwargs = dict(db_path=args.db_path, secrets_path=args.secrets_path, network=args.network)

--- a/allora_forge_builder_kit/workerctl.py
+++ b/allora_forge_builder_kit/workerctl.py
@@ -78,6 +78,10 @@ def main() -> None:
 
     p_link = sub.add_parser("link", help="Link local worker wallets to your Allora Forge account")
     p_link.add_argument("--forge-url", default=DEFAULT_FORGE_URL, help="Forge base URL")
+    # SUPPRESS so the subcommand flag doesn't clobber a top-level --secrets-path
+    # given before the subcommand, while still appearing in `link --help`.
+    p_link.add_argument("--secrets-path", default=argparse.SUPPRESS,
+                        help="WorkerManager secrets file (default: worker_secrets.json)")
     p_link.add_argument("--address", action="append", dest="addresses",
                         help="Limit to specific allo1... address(es); repeatable. Default: all local keys.")
     p_link.add_argument("--no-browser", action="store_true", help="Do not auto-open a browser")

--- a/allora_forge_builder_kit/workerctl.py
+++ b/allora_forge_builder_kit/workerctl.py
@@ -82,8 +82,12 @@ def main() -> None:
     # given before the subcommand, while still appearing in `link --help`.
     p_link.add_argument("--secrets-path", default=argparse.SUPPRESS,
                         help="WorkerManager secrets file (default: worker_secrets.json)")
-    p_link.add_argument("--address", action="append", dest="addresses",
-                        help="Limit to specific allo1... address(es); repeatable. Default: all local keys.")
+    p_link.add_argument(
+        "--address",
+        action="append",
+        dest="addresses",
+        help="Limit to specific allo1... address(es); repeatable. Default: all local keys.",
+    )
     p_link.add_argument("--no-browser", action="store_true", help="Do not auto-open a browser")
     p_link.add_argument("--insecure", action="store_true",
                         help="Allow a plaintext http:// forge URL (local dev only)")

--- a/allora_forge_builder_kit/workerctl.py
+++ b/allora_forge_builder_kit/workerctl.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 
 from .worker_manager import WorkerManager
 from .worker_monitor import WorkerMonitor, AlloraSDKEventFetcher
+from .wallet_link import DEFAULT_FORGE_URL, run_link
 
 
 def _make_manager(
@@ -75,12 +76,26 @@ def main() -> None:
     sub.add_parser("start-all", help="Start all enabled workers")
     sub.add_parser("stop-all", help="Stop running workers")
 
+    p_link = sub.add_parser("link", help="Link local worker wallets to your Allora Forge account")
+    p_link.add_argument("--forge-url", default=DEFAULT_FORGE_URL, help="Forge base URL")
+    p_link.add_argument("--address", action="append", dest="addresses",
+                        help="Limit to specific allo1... address(es); repeatable. Default: all local keys.")
+    p_link.add_argument("--no-browser", action="store_true", help="Do not auto-open a browser")
+
     args = parser.parse_args()
     mgr_kwargs = dict(db_path=args.db_path, secrets_path=args.secrets_path, network=args.network)
 
     if args.cmd == "dashboard":
         cmd_dashboard(with_monitor=not args.no_monitor, running_only=not args.all, **mgr_kwargs)
         return
+
+    if args.cmd == "link":
+        raise SystemExit(run_link(
+            forge_url=args.forge_url,
+            secrets_path=args.secrets_path,
+            addresses=args.addresses,
+            open_browser=not args.no_browser,
+        ))
 
     wm, _ = _make_manager(with_monitor=False, **mgr_kwargs)
     if args.cmd == "reconcile":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dev = [
 binance = [
     "websocket-client",
 ]
+wallet-link = [
+    "cosmpy==0.11.1",
+]
 
 [project.urls]
 Homepage = "https://github.com/allora-network/allora-forge-builder-kit"

--- a/tests/test_wallet_link.py
+++ b/tests/test_wallet_link.py
@@ -8,8 +8,13 @@ import json
 import pytest
 
 from allora_forge_builder_kit.wallet_link import (
+    _RequestError,
+    _is_terminal_poll_error,
+    _loads_json_object,
+    _submit_rejection,
     build_adr036_sign_doc,
     discover_keys,
+    SecretsLoadError,
 )
 
 # Byte-for-byte parity with the Go verifier's golden
@@ -43,6 +48,41 @@ def test_discover_keys_missing_file(tmp_path):
     assert discover_keys(str(tmp_path / "nope.json")) == {}
 
 
+def test_discover_keys_skips_non_string_entries(tmp_path):
+    # A tampered/malformed secrets file with non-string address/key_file must be skipped with a
+    # clean result, not crash inside _checked_key_file on Path(<int>) (only json/OSError are caught).
+    key_file = tmp_path / "w.key"
+    key_file.write_text("mnemonic")
+    secrets = tmp_path / "worker_secrets.json"
+    secrets.write_text(
+        json.dumps(
+            {
+                "bad_addr": {"address": 123, "key_file": str(key_file)},
+                "bad_kf": {"address": "allo1bad", "key_file": 456},
+                "good": {"address": "allo1good", "key_file": str(key_file)},
+            }
+        )
+    )
+    keys = discover_keys(str(secrets))
+    assert set(keys) == {"allo1good"}
+
+
+def test_discover_keys_raises_on_corrupt_json(tmp_path):
+    # A present-but-corrupt secrets file is distinct from absent: raise SecretsLoadError rather
+    # than return {} (which would mislead the caller into "no worker keys, create one").
+    secrets = tmp_path / "worker_secrets.json"
+    secrets.write_text("{not valid json")
+    with pytest.raises(SecretsLoadError):
+        discover_keys(str(secrets))
+
+
+def test_discover_keys_raises_on_non_object_root(tmp_path):
+    secrets = tmp_path / "worker_secrets.json"
+    secrets.write_text(json.dumps([1, 2, 3]))
+    with pytest.raises(SecretsLoadError):
+        discover_keys(str(secrets))
+
+
 def test_sign_roundtrip_with_cosmpy():
     """sign_challenge must round-trip against the address derived from the key,
     and produce a 33-byte pubkey + 64-byte signature the Go verifier accepts."""
@@ -60,6 +100,195 @@ def test_sign_roundtrip_with_cosmpy():
     assert len(base64.b64decode(signature_b64)) == 64
 
 
+def test_loads_json_object_accepts_object():
+    assert _loads_json_object("https://forge.example", '{"device_code": "abc"}') == {"device_code": "abc"}
+
+
+def test_loads_json_object_rejects_non_object_json():
+    # A JSON array/scalar/null would crash callers with AttributeError on .get(); reject cleanly.
+    for body in ("[1, 2, 3]", '"a string"', "null", "42"):
+        with pytest.raises(SystemExit):
+            _loads_json_object("https://forge.example", body)
+
+
+def test_loads_json_object_rejects_non_json_body():
+    # A truncated body or an HTML error page from an intermediary proxy must not raise an
+    # unwrapped JSONDecodeError; it becomes a SystemExit the poll loop can treat as transient.
+    with pytest.raises(SystemExit):
+        _loads_json_object("https://forge.example", "<html>502 Bad Gateway</html>")
+
+
+def test_is_terminal_poll_error_classifies_status():
+    # Terminal 4xx (except 408/429) stops the flow; 5xx / 408 / 429 / network / malformed retry.
+    assert _is_terminal_poll_error(_RequestError("x", status=404)) is True
+    assert _is_terminal_poll_error(_RequestError("x", status=400)) is True
+    assert _is_terminal_poll_error(_RequestError("x", status=403)) is True
+    assert _is_terminal_poll_error(_RequestError("x", status=500)) is False
+    assert _is_terminal_poll_error(_RequestError("x", status=503)) is False
+    assert _is_terminal_poll_error(_RequestError("x", status=429)) is False
+    assert _is_terminal_poll_error(_RequestError("x", status=408)) is False
+    assert _is_terminal_poll_error(_RequestError("x")) is False  # network error: status is None
+    assert _is_terminal_poll_error(SystemExit("malformed body")) is False  # no status attribute
+
+
+def test_post_json_http_error_carries_status(monkeypatch):
+    import io
+    import urllib.error
+
+    from allora_forge_builder_kit import wallet_link
+
+    def _raise(*args, **kwargs):
+        raise urllib.error.HTTPError("https://forge.example", 404, "Not Found", {}, io.BytesIO(b"nope"))
+
+    monkeypatch.setattr(wallet_link._OPENER, "open", _raise)
+    with pytest.raises(_RequestError) as excinfo:
+        wallet_link._post_json("https://forge.example", {})
+    assert excinfo.value.status == 404
+
+
+def test_post_json_opener_refuses_redirects():
+    # The start/submit opener must not follow 3xx: redirect_request returning None makes urllib
+    # raise HTTPError instead of re-POSTing the signed body to the redirect target.
+    from allora_forge_builder_kit import wallet_link
+
+    handler = wallet_link._NoRedirectHandler()
+    assert handler.redirect_request(None, None, 302, "Found", {}, "https://evil.example/") is None
+    assert any(isinstance(h, wallet_link._NoRedirectHandler) for h in wallet_link._OPENER.handlers)
+
+
+def test_submit_rejection_reports_rejected_signatures():
+    msg = _submit_rejection({"rejected": [{"address": "allo1abc", "reason": "bad signature"}]})
+    assert msg is not None
+    assert "allo1abc" in msg
+    assert "bad signature" in msg
+
+
+def test_submit_rejection_reports_top_level_error():
+    assert _submit_rejection({"error": "device code mismatch"}) is not None
+
+
+def test_submit_rejection_none_when_no_rejections():
+    assert _submit_rejection({"linked": []}) is None
+    assert _submit_rejection({"rejected": []}) is None
+    assert _submit_rejection({}) is None
+
+
+def test_jsonposter_selects_https_proxy_from_env(monkeypatch):
+    from allora_forge_builder_kit import wallet_link
+
+    monkeypatch.setattr(wallet_link.urllib.request, "getproxies", lambda: {"https": "http://proxy.local:3128"})
+    monkeypatch.setattr(wallet_link.urllib.request, "proxy_bypass", lambda host: False)
+    poster = wallet_link._JsonPoster("https://forge.example.com")
+    assert poster._proxy == ("proxy.local", 3128)
+
+
+def test_jsonposter_warns_on_proxy_without_explicit_port(monkeypatch, capsys):
+    from allora_forge_builder_kit import wallet_link
+
+    monkeypatch.setattr(wallet_link.urllib.request, "getproxies", lambda: {"https": "http://proxy.local"})
+    monkeypatch.setattr(wallet_link.urllib.request, "proxy_bypass", lambda host: False)
+    poster = wallet_link._JsonPoster("https://forge.example.com")
+    assert poster._proxy == ("proxy.local", None)  # port stays None (http.client defaults it)
+    err = capsys.readouterr().err
+    assert "no explicit port" in err and "443" in err
+
+
+def test_jsonposter_no_proxy_when_env_unset(monkeypatch):
+    from allora_forge_builder_kit import wallet_link
+
+    monkeypatch.setattr(wallet_link.urllib.request, "getproxies", lambda: {})
+    monkeypatch.setattr(wallet_link.urllib.request, "proxy_bypass", lambda host: False)
+    poster = wallet_link._JsonPoster("https://forge.example.com")
+    assert poster._proxy is None
+
+
+def test_jsonposter_respects_no_proxy_bypass(monkeypatch):
+    from allora_forge_builder_kit import wallet_link
+
+    monkeypatch.setattr(wallet_link.urllib.request, "getproxies", lambda: {"https": "http://proxy.local:3128"})
+    monkeypatch.setattr(wallet_link.urllib.request, "proxy_bypass", lambda host: True)
+    poster = wallet_link._JsonPoster("https://forge.example.com")
+    assert poster._proxy is None
+
+
+def test_jsonposter_connect_tunnels_https_through_proxy(monkeypatch):
+    from allora_forge_builder_kit import wallet_link
+
+    monkeypatch.setattr(wallet_link.urllib.request, "getproxies", lambda: {"https": "http://proxy.local:3128"})
+    monkeypatch.setattr(wallet_link.urllib.request, "proxy_bypass", lambda host: False)
+    poster = wallet_link._JsonPoster("https://forge.example.com:8443")
+    conn = poster._connect()
+    try:
+        # The socket targets the proxy; the CONNECT tunnel points at the real Forge host so TLS is
+        # still validated against it.
+        assert conn.host == "proxy.local"
+        assert conn.port == 3128
+        assert conn._tunnel_host == "forge.example.com"
+        assert conn._tunnel_port == 8443
+    finally:
+        conn.close()
+
+
+def test_jsonposter_authenticated_proxy_builds_proxy_authorization(monkeypatch):
+    import base64
+
+    from allora_forge_builder_kit import wallet_link
+
+    # Userinfo is percent-encoded (p%40ss == "p@ss") to confirm it is URL-unquoted before base64.
+    monkeypatch.setattr(
+        wallet_link.urllib.request, "getproxies", lambda: {"https": "http://user:p%40ss@proxy.local:3128"}
+    )
+    monkeypatch.setattr(wallet_link.urllib.request, "proxy_bypass", lambda host: False)
+    poster = wallet_link._JsonPoster("https://forge.example.com")
+
+    assert poster._proxy == ("proxy.local", 3128)  # host/port still parsed; creds kept separately
+    expected = "Basic " + base64.b64encode(b"user:p@ss").decode("ascii")
+    assert poster._proxy_auth == expected
+
+
+def test_jsonposter_unauthenticated_proxy_has_no_auth(monkeypatch):
+    from allora_forge_builder_kit import wallet_link
+
+    monkeypatch.setattr(wallet_link.urllib.request, "getproxies", lambda: {"https": "http://proxy.local:3128"})
+    monkeypatch.setattr(wallet_link.urllib.request, "proxy_bypass", lambda host: False)
+    poster = wallet_link._JsonPoster("https://forge.example.com")
+
+    assert poster._proxy == ("proxy.local", 3128)
+    assert poster._proxy_auth is None
+
+
+def test_jsonposter_connect_sends_proxy_auth_on_tunnel(monkeypatch):
+    import base64
+
+    from allora_forge_builder_kit import wallet_link
+
+    monkeypatch.setattr(
+        wallet_link.urllib.request, "getproxies", lambda: {"https": "http://user:pass@proxy.local:3128"}
+    )
+    monkeypatch.setattr(wallet_link.urllib.request, "proxy_bypass", lambda host: False)
+    poster = wallet_link._JsonPoster("https://forge.example.com:8443")
+    conn = poster._connect()
+    try:
+        expected = "Basic " + base64.b64encode(b"user:pass").decode("ascii")
+        # The credentials ride the CONNECT request, not the tunneled origin request.
+        assert conn._tunnel_headers.get("Proxy-Authorization") == expected
+    finally:
+        conn.close()
+
+
+def test_jsonposter_unauthenticated_tunnel_has_no_proxy_auth(monkeypatch):
+    from allora_forge_builder_kit import wallet_link
+
+    monkeypatch.setattr(wallet_link.urllib.request, "getproxies", lambda: {"https": "http://proxy.local:3128"})
+    monkeypatch.setattr(wallet_link.urllib.request, "proxy_bypass", lambda host: False)
+    poster = wallet_link._JsonPoster("https://forge.example.com:8443")
+    conn = poster._connect()
+    try:
+        assert "Proxy-Authorization" not in conn._tunnel_headers
+    finally:
+        conn.close()
+
+
 def test_sign_challenge_address_mismatch():
     """A mnemonic whose address differs from the requested one is rejected."""
     pytest.importorskip("cosmpy")
@@ -69,3 +298,147 @@ def test_sign_challenge_address_mismatch():
 
     with pytest.raises(ValueError):
         sign_challenge(generate_mnemonic(), "allo1definitelynottheright", "msg")
+
+
+def _setup_device_flow(monkeypatch, tmp_path, poll_result, addresses=("allo1aaa", "allo1bbb")):
+    """Drive run_link's device flow against a stubbed server returning ``poll_result`` on poll."""
+    from allora_forge_builder_kit import wallet_link
+
+    key_file = tmp_path / "w.key"
+    key_file.write_text("mnemonic")
+    secrets = tmp_path / "worker_secrets.json"
+    secrets.write_text(
+        json.dumps({a: {"address": a, "key_file": str(key_file)} for a in addresses})
+    )
+
+    def fake_post_json(url, payload, timeout=15.0):
+        if url.endswith("/device/start"):
+            return {
+                "device_code": "dev",
+                "user_code": "USER",
+                "verification_uri_complete": "https://forge.example/approve",
+                "interval": 1,
+                "expires_in": 5,
+                "challenges": [{"address": a, "message": "m"} for a in addresses],
+            }
+        return {"status": "submitted"}
+
+    class _FakePoller:
+        def __init__(self, *a, **k):
+            pass
+
+        def post(self, url, payload):
+            return poll_result
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(wallet_link, "_post_json", fake_post_json)
+    monkeypatch.setattr(wallet_link, "_JsonPoster", _FakePoller)
+    monkeypatch.setattr(wallet_link, "sign_challenge", lambda *a: ("pub", "sig"))
+    monkeypatch.setattr(wallet_link.webbrowser, "open", lambda url: False)
+    monkeypatch.setattr(wallet_link.time, "sleep", lambda s: None)
+    return str(secrets)
+
+
+def test_run_link_partial_linked_set_is_failure(tmp_path, monkeypatch, capsys):
+    # Approved but only a subset linked: must fail (exit 1) and name the dropped address, not
+    # silently exit 0 (which would signal success to CI for a partial/failed link).
+    from allora_forge_builder_kit import wallet_link
+
+    secrets = _setup_device_flow(monkeypatch, tmp_path, {"status": "approved", "linked": ["allo1aaa"]})
+    rc = wallet_link.run_link(forge_url="https://forge.example", secrets_path=secrets, open_browser=False)
+    assert rc == 1
+    assert "allo1bbb" in capsys.readouterr().err
+
+
+def test_run_link_null_linked_does_not_crash(tmp_path, monkeypatch):
+    # {"linked": null} previously made poll.get("linked", []) return None and crash len(None).
+    from allora_forge_builder_kit import wallet_link
+
+    secrets = _setup_device_flow(monkeypatch, tmp_path, {"status": "approved", "linked": None})
+    rc = wallet_link.run_link(forge_url="https://forge.example", secrets_path=secrets, open_browser=False)
+    assert rc == 1
+
+
+def test_run_link_full_linked_set_succeeds(tmp_path, monkeypatch):
+    from allora_forge_builder_kit import wallet_link
+
+    secrets = _setup_device_flow(
+        monkeypatch, tmp_path, {"status": "approved", "linked": ["allo1aaa", "allo1bbb"]}
+    )
+    rc = wallet_link.run_link(forge_url="https://forge.example", secrets_path=secrets, open_browser=False)
+    assert rc == 0
+
+
+def test_run_link_rejects_forge_url_with_path(capsys):
+    # https://forge.allora.network/api/v1 would yield a double /api/v1 and a confusing 404;
+    # reject it up front (before any network) with an actionable message.
+    from allora_forge_builder_kit import wallet_link
+
+    rc = wallet_link.run_link(forge_url="https://forge.example/api/v1", open_browser=False)
+    assert rc == 1
+    assert "path" in capsys.readouterr().err.lower()
+
+
+def test_run_link_rejects_verification_url_on_different_port(tmp_path, monkeypatch, capsys):
+    # A compromised server returning the approval URL on a different port of the same host must be
+    # refused: the port is part of the origin the CLI pins.
+    from allora_forge_builder_kit import wallet_link
+
+    key_file = tmp_path / "w.key"
+    key_file.write_text("mnemonic")
+    secrets = tmp_path / "worker_secrets.json"
+    secrets.write_text(json.dumps({"allo1aaa": {"address": "allo1aaa", "key_file": str(key_file)}}))
+
+    def fake_post_json(url, payload, timeout=15.0):
+        return {
+            "device_code": "dev",
+            "user_code": "USER",
+            "verification_uri_complete": "https://forge.example:8443/approve",
+            "interval": 1,
+            "expires_in": 5,
+            "challenges": [{"address": "allo1aaa", "message": "m"}],
+        }
+
+    monkeypatch.setattr(wallet_link, "_post_json", fake_post_json)
+    rc = wallet_link.run_link(forge_url="https://forge.example", secrets_path=str(secrets), open_browser=False)
+    assert rc == 1
+    assert "untrusted verification URL" in capsys.readouterr().err
+
+
+def test_jsonposter_closes_connection_on_http_error(monkeypatch):
+    # A >= 400 response raises _RequestError (a BaseException the keep-alive except clause won't
+    # catch), so the connection must be closed first — otherwise the next poll reuses a connection
+    # whose body may be undrained and defeats keep-alive.
+    from allora_forge_builder_kit import wallet_link
+
+    class _FakeResp:
+        status = 403
+
+        def read(self, n):
+            return b"denied"
+
+    class _FakeConn:
+        def __init__(self):
+            self.closed = False
+
+        def request(self, *a, **k):
+            pass
+
+        def getresponse(self):
+            return _FakeResp()
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(wallet_link.urllib.request, "getproxies", lambda: {})
+    monkeypatch.setattr(wallet_link.urllib.request, "proxy_bypass", lambda host: False)
+    poster = wallet_link._JsonPoster("https://forge.example.com")
+    fake = _FakeConn()
+    poster._conn = fake
+    with pytest.raises(wallet_link._RequestError) as ei:
+        poster.post("https://forge.example.com/poll", {})
+    assert ei.value.status == 403
+    assert fake.closed is True       # the dirty connection was closed
+    assert poster._conn is None      # so the next poll reconnects fresh

--- a/tests/test_wallet_link.py
+++ b/tests/test_wallet_link.py
@@ -1,0 +1,71 @@
+"""Tests for the wallet-link device-flow CLI (ENGN-8614)."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+from allora_forge_builder_kit.wallet_link import (
+    build_adr036_sign_doc,
+    discover_keys,
+)
+
+# Byte-for-byte parity with the Go verifier's golden
+# (forge-v2/backend/internal/service/adr036_test.go TestBuildADR036SignDoc_Golden).
+GO_GOLDEN = (
+    b'{"account_number":"0","chain_id":"","fee":{"amount":[],"gas":"0"},'
+    b'"memo":"","msgs":[{"type":"sign/MsgSignData","value":{"data":'
+    b'"aGVsbG8gd29ybGQ=","signer":"allo1xyz"}}],"sequence":"0"}'
+)
+
+
+def test_adr036_doc_matches_go_golden():
+    assert build_adr036_sign_doc("allo1xyz", "hello world") == GO_GOLDEN
+
+
+def test_discover_keys(tmp_path):
+    key_file = tmp_path / "w.key"
+    key_file.write_text("twelve word mnemonic goes here ...")
+    secrets = tmp_path / "worker_secrets.json"
+    secrets.write_text(
+        json.dumps({"alias1": {"address": "allo1abc", "key_file": str(key_file)}})
+    )
+
+    keys = discover_keys(str(secrets))
+    assert "allo1abc" in keys
+    assert keys["allo1abc"]["alias"] == "alias1"
+    assert keys["allo1abc"]["key_file"] == str(key_file)
+
+
+def test_discover_keys_missing_file(tmp_path):
+    assert discover_keys(str(tmp_path / "nope.json")) == {}
+
+
+def test_sign_roundtrip_with_cosmpy():
+    """sign_challenge must round-trip against the address derived from the key,
+    and produce a 33-byte pubkey + 64-byte signature the Go verifier accepts."""
+    pytest.importorskip("cosmpy")
+    from cosmpy.aerial.wallet import LocalWallet
+    from cosmpy.mnemonic import generate_mnemonic
+
+    from allora_forge_builder_kit.wallet_link import sign_challenge
+
+    mnemonic = generate_mnemonic()
+    address = str(LocalWallet.from_mnemonic(mnemonic, "allo").address())
+
+    pubkey_b64, signature_b64 = sign_challenge(mnemonic, address, "verify me")
+    assert len(base64.b64decode(pubkey_b64)) == 33
+    assert len(base64.b64decode(signature_b64)) == 64
+
+
+def test_sign_challenge_address_mismatch():
+    """A mnemonic whose address differs from the requested one is rejected."""
+    pytest.importorskip("cosmpy")
+    from cosmpy.mnemonic import generate_mnemonic
+
+    from allora_forge_builder_kit.wallet_link import sign_challenge
+
+    with pytest.raises(ValueError):
+        sign_challenge(generate_mnemonic(), "allo1definitelynottheright", "msg")

--- a/tests/test_wallet_link.py
+++ b/tests/test_wallet_link.py
@@ -442,3 +442,349 @@ def test_jsonposter_closes_connection_on_http_error(monkeypatch):
     assert ei.value.status == 403
     assert fake.closed is True       # the dirty connection was closed
     assert poster._conn is None      # so the next poll reconnects fresh
+
+
+# --- Security-hardening regression tests (ENGN-8614 review round) --------------------------------
+
+
+def test_printable_strips_zero_width_and_bidi_chars():
+    # _printable must drop Unicode Cf/control codepoints (zero-width, BOM, bidi controls, ESC) so a
+    # server can't hide invisible/lookalike characters inside an address or code shown to the user.
+    from allora_forge_builder_kit.wallet_link import _printable
+
+    dangerous = "allo1abc\u200b\u200c\u200d\u202e\u2066\ufeff\x1b[2J"
+    out = _printable(dangerous)
+    assert out == "allo1abc[2J"  # visible text kept; ESC + every Cf char removed
+    for cp in (0x200B, 0x200C, 0x200D, 0x200E, 0x200F, 0x202A, 0x202B, 0x202C,
+               0x202D, 0x202E, 0x2060, 0x2066, 0x2067, 0x2068, 0x2069, 0xFEFF):
+        assert chr(cp) not in out
+
+
+def test_loads_json_object_sanitizes_non_json_error():
+    # The non-JSON error path must run the raw body through _printable before it reaches stderr.
+    with pytest.raises(SystemExit) as ei:
+        _loads_json_object("https://forge.example", "\x1b[2Jmalicious\u200b")
+    msg = str(ei.value)
+    assert "\x1b" not in msg and "\u200b" not in msg
+    assert "malicious" in msg
+
+
+def test_is_terminal_poll_error_treats_3xx_as_terminal():
+    # A 3xx on the poll path is a misconfiguration (e.g. http->https redirect) that never resolves
+    # by retrying, so it must be classified terminal alongside 4xx.
+    assert _is_terminal_poll_error(_RequestError("x", status=301)) is True
+    assert _is_terminal_poll_error(_RequestError("x", status=302)) is True
+    assert _is_terminal_poll_error(_RequestError("x", status=308)) is True
+
+
+def test_build_adr036_sign_doc_rejects_non_alphanumeric_signer():
+    # The injection guard must reject anything outside [a-z0-9] so a signer can't corrupt the JSON.
+    for bad in ("allo1ABC", 'allo1"', "allo1\\", "allo1;rm", "allo1 x", "allo1\x1b"):
+        with pytest.raises(ValueError):
+            build_adr036_sign_doc(bad, "msg")
+
+
+def test_post_json_retrying_retries_transient_then_succeeds(monkeypatch):
+    from allora_forge_builder_kit import wallet_link
+
+    calls = {"n": 0}
+
+    def flaky(url, payload, timeout=15.0):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise wallet_link._RequestError("temporary", status=503)  # transient -> retry
+        return {"status": "submitted"}
+
+    monkeypatch.setattr(wallet_link, "_post_json", flaky)
+    monkeypatch.setattr(wallet_link.time, "sleep", lambda s: None)
+    out = wallet_link._post_json_retrying("https://forge.example/submit", {}, attempts=3, backoff=0)
+    assert out == {"status": "submitted"}
+    assert calls["n"] == 3
+
+
+def test_post_json_retrying_reraises_terminal_immediately(monkeypatch):
+    from allora_forge_builder_kit import wallet_link
+
+    calls = {"n": 0}
+
+    def terminal(url, payload, timeout=15.0):
+        calls["n"] += 1
+        raise wallet_link._RequestError("bad request", status=400)  # terminal -> no retry
+
+    monkeypatch.setattr(wallet_link, "_post_json", terminal)
+    monkeypatch.setattr(wallet_link.time, "sleep", lambda s: None)
+    with pytest.raises(wallet_link._RequestError):
+        wallet_link._post_json_retrying("https://forge.example/submit", {}, attempts=3, backoff=0)
+    assert calls["n"] == 1
+
+
+def test_jsonposter_treats_3xx_as_error(monkeypatch):
+    # A 3xx response must raise _RequestError (not fall through to _loads_json_object and spin).
+    from allora_forge_builder_kit import wallet_link
+
+    class _FakeResp:
+        status = 302
+
+        def read(self, n):
+            return b"redirecting"
+
+    class _FakeConn:
+        def request(self, *a, **k):
+            pass
+
+        def getresponse(self):
+            return _FakeResp()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(wallet_link.urllib.request, "getproxies", lambda: {})
+    monkeypatch.setattr(wallet_link.urllib.request, "proxy_bypass", lambda host: False)
+    poster = wallet_link._JsonPoster("https://forge.example.com")
+    poster._conn = _FakeConn()
+    with pytest.raises(wallet_link._RequestError) as ei:
+        poster.post("https://forge.example.com/poll", {})
+    assert ei.value.status == 302
+
+
+def test_jsonposter_closes_connection_on_malformed_200(monkeypatch):
+    # A non-JSON 200 body raises SystemExit; the connection must be closed so the next poll
+    # reconnects instead of reusing a dirty socket (matches the >= 400 path).
+    from allora_forge_builder_kit import wallet_link
+
+    class _FakeResp:
+        status = 200
+
+        def read(self, n):
+            return b"<html>not json</html>"
+
+    class _FakeConn:
+        def __init__(self):
+            self.closed = False
+
+        def request(self, *a, **k):
+            pass
+
+        def getresponse(self):
+            return _FakeResp()
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(wallet_link.urllib.request, "getproxies", lambda: {})
+    monkeypatch.setattr(wallet_link.urllib.request, "proxy_bypass", lambda host: False)
+    poster = wallet_link._JsonPoster("https://forge.example.com")
+    fake = _FakeConn()
+    poster._conn = fake
+    with pytest.raises(SystemExit):
+        poster.post("https://forge.example.com/poll", {})
+    assert fake.closed is True
+    assert poster._conn is None
+
+
+def test_run_link_sign_failure_does_not_leak_mnemonic(tmp_path, monkeypatch, capsys):
+    # A signing exception whose message embeds mnemonic words must NOT reach stderr; only the
+    # exception type is surfaced.
+    from allora_forge_builder_kit import wallet_link
+
+    secrets = _setup_device_flow(
+        monkeypatch, tmp_path, {"status": "approved", "linked": []}, addresses=("allo1aaa",)
+    )
+    secret_words = "abandon ability able about above absent absorb"
+
+    def boom(*a, **k):
+        raise RuntimeError(f"cosmpy internal error: {secret_words}")
+
+    monkeypatch.setattr(wallet_link, "sign_challenge", boom)
+    rc = wallet_link.run_link(
+        forge_url="https://forge.example", secrets_path=secrets, open_browser=False
+    )
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert secret_words not in err
+    assert "abandon" not in err
+    assert "RuntimeError" in err  # type is safe to show
+
+
+def test_run_link_wallet_sign_error_message_is_shown(tmp_path, monkeypatch, capsys):
+    # WalletSignError carries a key-material-free message (address mismatch) and IS shown verbatim.
+    from allora_forge_builder_kit import wallet_link
+
+    secrets = _setup_device_flow(
+        monkeypatch, tmp_path, {"status": "approved"}, addresses=("allo1aaa",)
+    )
+
+    def mismatch(*a, **k):
+        raise wallet_link.WalletSignError(
+            "key derives address allo1zzz, which does not match requested allo1aaa"
+        )
+
+    monkeypatch.setattr(wallet_link, "sign_challenge", mismatch)
+    rc = wallet_link.run_link(
+        forge_url="https://forge.example", secrets_path=secrets, open_browser=False
+    )
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "allo1zzz" in err
+
+
+def test_run_link_empty_key_file_is_clear_error(tmp_path, monkeypatch, capsys):
+    # A whitespace-only key file must fail with a clear "empty" message before cosmpy is called.
+    from allora_forge_builder_kit import wallet_link
+
+    secrets = _setup_device_flow(
+        monkeypatch, tmp_path, {"status": "approved"}, addresses=("allo1aaa",)
+    )
+    (tmp_path / "w.key").write_text("   \n\t")
+    rc = wallet_link.run_link(
+        forge_url="https://forge.example", secrets_path=secrets, open_browser=False
+    )
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "empty" in err.lower()
+
+
+def test_run_link_deduplicates_addresses(tmp_path, monkeypatch):
+    # Repeated --address X --address X must collapse to a single challenge + signature.
+    from allora_forge_builder_kit import wallet_link
+
+    key_file = tmp_path / "w.key"
+    key_file.write_text("mnemonic")
+    secrets = tmp_path / "worker_secrets.json"
+    secrets.write_text(json.dumps({"allo1aaa": {"address": "allo1aaa", "key_file": str(key_file)}}))
+    captured = {}
+
+    def fake_post_json(url, payload, timeout=15.0):
+        if url.endswith("/device/start"):
+            captured["start_addresses"] = list(payload["addresses"])
+            return {
+                "device_code": "dev",
+                "user_code": "U",
+                "verification_uri_complete": "https://forge.example/approve",
+                "interval": 1,
+                "expires_in": 5,
+                "challenges": [{"address": "allo1aaa", "message": "m"}],
+            }
+        captured["submit_sigs"] = list(payload["signatures"])
+        return {"status": "submitted"}
+
+    class _P:
+        def __init__(self, *a, **k):
+            pass
+
+        def post(self, u, p):
+            return {"status": "approved", "linked": ["allo1aaa"]}
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(wallet_link, "_post_json", fake_post_json)
+    monkeypatch.setattr(wallet_link, "_JsonPoster", _P)
+    monkeypatch.setattr(wallet_link, "sign_challenge", lambda *a: ("pub", "sig"))
+    monkeypatch.setattr(wallet_link.webbrowser, "open", lambda u: False)
+    monkeypatch.setattr(wallet_link.time, "sleep", lambda s: None)
+    rc = wallet_link.run_link(
+        forge_url="https://forge.example",
+        secrets_path=str(secrets),
+        addresses=["allo1aaa", "allo1aaa"],
+        open_browser=False,
+    )
+    assert rc == 0
+    assert captured["start_addresses"] == ["allo1aaa"]
+    assert len(captured["submit_sigs"]) == 1
+
+
+def test_run_link_empty_address_list_fails_closed(tmp_path, monkeypatch, capsys):
+    # addresses=[] must link nothing and never hit the network (not fall back to linking all).
+    from allora_forge_builder_kit import wallet_link
+
+    key_file = tmp_path / "w.key"
+    key_file.write_text("mnemonic")
+    secrets = tmp_path / "worker_secrets.json"
+    secrets.write_text(
+        json.dumps(
+            {
+                "allo1aaa": {"address": "allo1aaa", "key_file": str(key_file)},
+                "allo1bbb": {"address": "allo1bbb", "key_file": str(key_file)},
+            }
+        )
+    )
+    called = {"start": False}
+
+    def fake_post_json(url, payload, timeout=15.0):
+        called["start"] = True
+        return {}
+
+    monkeypatch.setattr(wallet_link, "_post_json", fake_post_json)
+    rc = wallet_link.run_link(
+        forge_url="https://forge.example", secrets_path=str(secrets), addresses=[], open_browser=False
+    )
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "no addresses" in err.lower()
+    assert called["start"] is False
+
+
+def test_run_link_unknown_poll_status_gives_up(tmp_path, monkeypatch, capsys):
+    # An unrecognized poll status must bail (bounded) instead of polling silently to the deadline.
+    from allora_forge_builder_kit import wallet_link
+
+    secrets = _setup_device_flow(monkeypatch, tmp_path, {"status": "wat"}, addresses=("allo1aaa",))
+    rc = wallet_link.run_link(
+        forge_url="https://forge.example", secrets_path=secrets, open_browser=False
+    )
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "unrecognized poll status" in err
+
+
+def test_run_link_persistent_poll_error_gives_up(tmp_path, monkeypatch, capsys):
+    # A consistently malformed/transient poll response must give up after the consecutive bound
+    # rather than retry for the full deadline.
+    from allora_forge_builder_kit import wallet_link
+
+    secrets = _setup_device_flow(monkeypatch, tmp_path, None, addresses=("allo1aaa",))
+
+    class _Boom:
+        def __init__(self, *a, **k):
+            pass
+
+        def post(self, u, p):
+            raise SystemExit("malformed body")  # no status -> transient
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(wallet_link, "_JsonPoster", _Boom)
+    rc = wallet_link.run_link(
+        forge_url="https://forge.example", secrets_path=secrets, open_browser=False
+    )
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "consecutive poll errors" in err
+
+
+def test_run_link_authorization_pending_then_approved(tmp_path, monkeypatch):
+    # The forge-v2 pending status ("authorization_pending") must keep polling, then succeed.
+    from allora_forge_builder_kit import wallet_link
+
+    secrets = _setup_device_flow(monkeypatch, tmp_path, None, addresses=("allo1aaa",))
+
+    class _Pending:
+        def __init__(self, *a, **k):
+            self.n = 0
+
+        def post(self, u, p):
+            self.n += 1
+            if self.n < 3:
+                return {"status": "authorization_pending"}
+            return {"status": "approved", "linked": ["allo1aaa"]}
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(wallet_link, "_JsonPoster", _Pending)
+    rc = wallet_link.run_link(
+        forge_url="https://forge.example", secrets_path=secrets, open_browser=False
+    )
+    assert rc == 0


### PR DESCRIPTION
## Summary
Adds `workerctl link` (and `python -m allora_forge_builder_kit.wallet_link`) for [ENGN-8614](https://linear.app/alloralabs/issue/ENGN-8614): a `gh auth login`-style device flow that signs an ADR-036 challenge with the on-disk worker key (cosmpy), opens the browser for the logged-in Forge user to approve, and polls to completion. The mnemonic never leaves the dev kit and it works headless.

The server side lives in `forge-v2` (companion PR). Per ENGN-8594 this verb is slated to live in the SDK (`allora-sdk-py`) long-term; scaffolded here since the builder kit already manages the worker keys.

## Test plan
- [x] `py_compile`; ADR-036 sign-doc byte-parity with the Go verifier's golden
- [ ] `pytest tests/test_wallet_link.py` in an env with cosmpy installed
- [ ] end-to-end link against a running Forge backend

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a gh-auth-login-style device flow to link local worker wallets to a logged-in Forge account using ADR-036 signatures. Exposed as `workerctl link` (and `python -m allora_forge_builder_kit.wallet_link`) to support ENGN-8614 by proving wallet ownership for verified-worker submissions.

- **Bug Fixes**
  - Prevent key leaks: never print mnemonic or raw crypto errors; add `WalletSignError` (safe message), enforce UTF-8 and non-empty key files.
  - Pre-validate `cosmpy` before starting a device session; optional `wallet-link` extra still installs `cosmpy==0.11.1`.
  - Retry `/device/submit` on transient failures; treat 3xx and terminal 4xx as fatal; sanitize non-JSON bodies; keep bounded response reads.
  - Poll hardening: classify 3xx as errors, close/reconnect dirty keep-alive sockets, bound consecutive poll errors and unknown statuses; honor `expires_in` and clamp `interval` to the deadline.
  - Input robustness: deduplicate repeated `--address` values and fail closed on an empty list; handle headless browsers via `webbrowser.open()` return value.

- **Refactors**
  - Share CLI flags via `add_link_arguments` so `workerctl link` and the standalone entry stay in sync.

<sup>Written for commit f6711eba6f187b0f81156b1097ddb29c041596c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-forge-builder-kit/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

