### PR TITLE
Claude/trusting wright 1pmzte

### DIFF
--- a/forge_models/README.md
+++ b/forge_models/README.md
@@ -1,0 +1,65 @@
+# forge_models — unified Allora Forge training scripts
+
+One `train_topic_<id>.py` per competition. Each script builds, evaluates, and
+exports a **self-contained** `predict.pkl` into the repo-level `models/` folder
+as `predict_topic_<id>.pkl`. Shared machinery lives in `common/`, so the
+per-topic scripts stay thin and bug fixes happen in one place.
+
+## Layout
+
+```
+forge_models/
+  common/
+    config.py        # cross-competition constants + model_path() helper
+    data.py          # resolve_data_source(): allora (Tiingo) w/ binance fallback
+    features.py      # matrices_from_workflow_df, compact_features (~30 stationary feats)
+    calibration.py   # zptae_proxy, aspect_ratio, tune_shrink (shrinkage λ)
+    export.py        # export_predict(): atomic, verified, self-contained .pkl
+  train_topic_72.py  # 1h BTC/USD log-return
+  ...
+models/
+  predict_topic_72.pkl   # written by the script (git-ignored)
+```
+
+## Run
+
+```bash
+export ALLORA_API_KEY=UP-...                 # free at developer.allora.network
+python forge_models/train_topic_72.py        # -> models/predict_topic_72.pkl
+```
+
+No API key? The scripts fall back to Binance klines automatically
+(`DATA_SOURCE=binance` forces it).
+
+## Deploy
+
+The deploy scripts read `PREDICT_PKL` and `TOPIC_ID`:
+
+```bash
+PREDICT_PKL=models/predict_topic_72.pkl TOPIC_ID=72 \
+    python notebooks/deploy_worker.py
+```
+
+## Self-contained artifacts (why `common/` is safe)
+
+The exported `predict()` calls helpers from `common/features.py`. cloudpickle
+would normally pickle those *by reference*, which would force the deployed
+worker to have `forge_models` installed. `export_predict()` registers the
+shared modules for **pickle-by-value** (`cloudpickle.register_pickle_by_value`),
+so the `.pkl` carries the code with it — exactly as if everything lived in the
+training script's `__main__`. The worker needs only the runtime deps
+(`lightgbm`, `pandas`, `allora_forge_builder_kit`), not this package.
+
+## Adding a new competition
+
+1. Copy `train_topic_72.py` to `train_topic_<id>.py`.
+2. Update the **competition identity** block: `TOPIC_ID`, `INTERVAL`,
+   `TARGET_BARS`, `ALLORA_TICKERS`, `BINANCE_TICKERS`.
+3. Adjust the target/feature/predict logic for the topic's spec (e.g. if it
+   asks for a price rather than a log-return, or a different horizon).
+4. Reuse `common/` for features, calibration, data, and export. Promote any
+   genuinely shared new helper into `common/` rather than copying it.
+
+> Whitelist targets (log-return topics): DA > 0.55, Pearson r > 0.05,
+> WRMSE improvement vs zero > 10%, WZPTAE improvement vs zero > 20%,
+> `|log10(std_pred/std_true)| < 0.5`.

--- a/forge_models/__init__.py
+++ b/forge_models/__init__.py
@@ -1,0 +1,6 @@
+"""Allora Forge training scripts, unified.
+
+One ``train_topic_<id>.py`` per competition. Each builds, evaluates, and
+exports a self-contained ``predict.pkl`` into the repo's ``models/`` folder,
+named ``predict_topic_<id>.pkl``. Shared machinery lives in ``common/``.
+"""

--- a/forge_models/common/__init__.py
+++ b/forge_models/common/__init__.py
@@ -1,0 +1,22 @@
+"""Reusable building blocks shared by the per-topic Forge training scripts."""
+from __future__ import annotations
+
+from .config import (
+    REPO_ROOT, MODELS_DIR, model_path,
+    SIGMA_WINDOW, Z_CLIP, SHRINK_GRID, ASPECT_BOUND,
+    FIXED_COMMON, REG_EXTRA, RET_LAGS, VOL_WINDOWS,
+)
+from .data import load_api_key, resolve_data_source
+from .features import matrices_from_workflow_df, compact_features
+from .calibration import power_tanh, zptae_proxy, aspect_ratio, tune_shrink
+from .export import export_predict
+
+__all__ = [
+    "REPO_ROOT", "MODELS_DIR", "model_path",
+    "SIGMA_WINDOW", "Z_CLIP", "SHRINK_GRID", "ASPECT_BOUND",
+    "FIXED_COMMON", "REG_EXTRA", "RET_LAGS", "VOL_WINDOWS",
+    "load_api_key", "resolve_data_source",
+    "matrices_from_workflow_df", "compact_features",
+    "power_tanh", "zptae_proxy", "aspect_ratio", "tune_shrink",
+    "export_predict",
+]

--- a/forge_models/common/calibration.py
+++ b/forge_models/common/calibration.py
@@ -1,0 +1,88 @@
+"""ZPTAE-proxy scoring and magnitude (shrinkage) calibration.
+
+These are training/evaluation-time utilities — they are NOT referenced inside
+the exported ``predict()`` closure, so they don't need to be picklable. They
+exist so every topic script scores and calibrates predictions the same way the
+Forge whitelist criteria do.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from .config import SIGMA_WINDOW, SHRINK_GRID, ASPECT_BOUND
+
+
+def power_tanh(x: np.ndarray, p: float = 1.5) -> np.ndarray:
+    """Smooth bounded transform — a stand-in for the competition's power-tanh.
+    Only used to compare *relative* loss vs the zero baseline."""
+    return np.tanh(np.abs(x)) ** p
+
+
+def zptae_proxy(y_true: np.ndarray, y_pred: np.ndarray, window: int = SIGMA_WINDOW) -> float:
+    """Mean power-tanh of |error| z-scored by the trailing std of the last
+    ``window`` ground-truth log-returns (ref mean 0), like the topic's loss."""
+    s = pd.Series(y_true)
+    sigma = s.rolling(window, min_periods=window).std().shift(1).to_numpy()
+    ok = np.isfinite(sigma) & (sigma > 0)
+    if ok.sum() == 0:
+        return float("nan")
+    z = np.abs(y_pred[ok] - y_true[ok]) / sigma[ok]
+    return float(np.mean(power_tanh(z)))
+
+
+def aspect_ratio(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    return float(np.log10((y_pred.std() + 1e-15) / (y_true.std() + 1e-15)))
+
+
+def tune_shrink(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    shrink_grid=SHRINK_GRID,
+    aspect_bound: float = ASPECT_BOUND,
+    strict_aspect: bool = False,
+    verbose: bool = False,
+) -> tuple[float, float, float]:
+    """Pick a scale lambda for the predictions, balancing two pulls:
+
+    * ZPTAE/WRMSE want weak signals scaled way down (the RMSE-optimal scale is
+      lambda* = cov(pred, true)/var(pred), tiny when correlation is low);
+    * the whitelist's |log10(std(pred)/std(true))| <= aspect_bound sets a
+      *floor* on loudness — silence is not an option.
+
+    Candidates: fixed grid + lambda* + the aspect-feasibility boundaries.
+    Policy: take the best feasible lambda unless the unconstrained best beats
+    it by more than 2pp of improvement, in which case prefer score (set
+    strict_aspect=True to always stay in the whitelist band).
+    Returns (lambda, zptae_improvement, aspect).
+    """
+    eps = 1e-15
+    zp_zero = zptae_proxy(y_true, np.zeros_like(y_pred))
+    sy, sp = y_true.std() + eps, y_pred.std() + eps
+    lam_floor = (10.0 ** -aspect_bound) * sy / sp     # quietest feasible
+    lam_ceil = (10.0 ** aspect_bound) * sy / sp       # loudest feasible
+    lam_star = float(np.dot(y_pred, y_true) / (np.dot(y_pred, y_pred) + eps))
+    cands = set(shrink_grid) | {lam_floor * 1.01, lam_ceil * 0.99}
+    if lam_star > 0:
+        cands |= {lam_star, min(max(lam_star, lam_floor * 1.01), lam_ceil * 0.99)}
+
+    best, best_feasible = None, None
+    for lam in sorted(c for c in cands if c > 0):
+        zp = zptae_proxy(y_true, lam * y_pred)
+        imp = 1.0 - zp / zp_zero if zp_zero and np.isfinite(zp) else float("-inf")
+        asp = aspect_ratio(y_true, lam * y_pred)
+        cand = (imp, lam, asp)
+        if best is None or imp > best[0]:
+            best = cand
+        if abs(asp) <= aspect_bound and (best_feasible is None or imp > best_feasible[0]):
+            best_feasible = cand
+    chosen = best
+    if best_feasible is not None and (strict_aspect or best_feasible[0] >= best[0] - 0.02):
+        chosen = best_feasible
+    elif verbose and best_feasible is not None:
+        print(f"  note: taking lambda={best[1]:.3f} for score; aspect {best[2]:+.2f} "
+              f"violates the +/-{aspect_bound} whitelist bound "
+              f"(best feasible was {best_feasible[0]:+.2%} at lambda={best_feasible[1]:.3f};"
+              f" strict_aspect=True forces compliance)")
+    imp, lam, asp = chosen
+    return lam, imp, asp

--- a/forge_models/common/config.py
+++ b/forge_models/common/config.py
@@ -1,0 +1,48 @@
+"""Shared defaults for Allora Forge training scripts.
+
+These are *cross-competition* constants — things tied to how the Forge scores
+log-return topics rather than to any single asset/interval. Competition-specific
+knobs (interval, target_bars, input_bars, tickers, half-life, ...) live in the
+per-topic script, not here.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+# --- repo layout ---------------------------------------------------------
+# forge_models/common/config.py  ->  parents[2] == repo root
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODELS_DIR = REPO_ROOT / "models"
+
+
+def model_path(topic_id: int | str, prefix: str = "predict") -> Path:
+    """Canonical artifact path for a topic, e.g. models/predict_topic_72.pkl.
+
+    The deploy scripts read PREDICT_PKL, so point them here:
+        PREDICT_PKL=models/predict_topic_72.pkl TOPIC_ID=72 \
+            python notebooks/deploy_worker.py
+    """
+    MODELS_DIR.mkdir(parents=True, exist_ok=True)
+    return MODELS_DIR / f"{prefix}_topic_{topic_id}.pkl"
+
+
+# --- scoring reference (shared across log-return topics) -----------------
+# The Forge ZPTAE/WZPTAE reference std is computed over a rolling window of the
+# last 100 ground-truth log-returns; keep the model's vol reference in sync.
+SIGMA_WINDOW = 100
+Z_CLIP = 6.0                       # clip vol-normalized targets' tails
+
+# --- magnitude calibration (whitelist constraints) -----------------------
+SHRINK_GRID = [0.25, 0.4, 0.6, 0.8, 1.0, 1.3]
+ASPECT_BOUND = 0.5                 # |log10(std(pred)/std(true))| < 0.5
+
+# --- conservative LightGBM defaults shared by the topic scripts ----------
+FIXED_COMMON = dict(
+    min_child_samples=100, subsample=0.8, subsample_freq=1,
+    colsample_bytree=0.8, reg_lambda=1.0, random_state=42, verbose=-1,
+)
+REG_EXTRA = dict(objective="huber", alpha=1.0)
+
+# --- default compact-feature geometry ------------------------------------
+RET_LAGS = (1, 2, 3, 4, 6, 12, 24, 48, 96)
+VOL_WINDOWS = (6, 24, 96)

--- a/forge_models/common/data.py
+++ b/forge_models/common/data.py
@@ -1,0 +1,47 @@
+"""Data-source resolution shared by the topic scripts.
+
+Prefer the Allora/Tiingo source (it matches how topics are scored); fall back
+to Binance klines when no API key is available.
+"""
+from __future__ import annotations
+
+import os
+
+
+def load_api_key() -> str:
+    """Read ALLORA_API_KEY from the env, then from common dotfiles."""
+    api_key = os.environ.get("ALLORA_API_KEY", "").strip()
+    if api_key:
+        return api_key
+    for p in (".allora_api_key", "notebooks/.allora_api_key"):
+        if os.path.exists(p):
+            return open(p).read().strip()
+    return ""
+
+
+def resolve_data_source(
+    allora_tickers: list[str],
+    binance_tickers: list[str],
+) -> tuple[str, list[str], dict]:
+    """Return (data_source, tickers, data_manager_kwargs).
+
+    DATA_SOURCE=allora|binance forces a source; otherwise we use allora when an
+    API key is present and fall back to binance when it is not. The two ticker
+    lists let each competition spell its symbol per source (e.g. ``btcusd`` vs
+    ``BTCUSDT``).
+    """
+    forced = os.environ.get("DATA_SOURCE", "").strip().lower()
+    api_key = load_api_key()
+
+    if forced == "binance" or (not api_key and forced != "allora"):
+        reason = "forced" if forced == "binance" else "no ALLORA_API_KEY found"
+        print(f"Data source: binance ({reason})")
+        return "binance", list(binance_tickers), {}
+
+    if not api_key:
+        raise SystemExit(
+            "ALLORA_API_KEY required for DATA_SOURCE=allora — "
+            "get one free at https://developer.allora.network"
+        )
+    print("Data source: allora (Tiingo via Atlas)")
+    return "allora", list(allora_tickers), {"api_key": api_key}

--- a/forge_models/common/export.py
+++ b/forge_models/common/export.py
@@ -1,0 +1,49 @@
+"""Self-contained, atomic export of a ``predict()`` closure to a .pkl artifact.
+
+The exported ``predict`` calls helpers from ``forge_models.common.features``.
+By default cloudpickle would pickle those *by reference*, which would force the
+deployed worker to have ``forge_models`` importable. We instead register the
+shared modules for **pickle-by-value** so the artifact is fully self-contained
+— exactly as it would be if everything lived in the training script's
+``__main__``. This is what lets the topic scripts stay thin without breaking
+deployment.
+
+Export is atomic and verified: a crash mid-dump must never leave a truncated
+predict.pkl behind (a 0-byte artifact crashes the worker with EOFError).
+"""
+from __future__ import annotations
+
+import os
+import pickle
+from pathlib import Path
+
+import cloudpickle
+
+from . import features as _features
+from . import config as _config
+
+
+def export_predict(predict_fn, out_path, extra_by_value_modules=()) -> Path:
+    """Pickle ``predict_fn`` to ``out_path`` atomically, self-contained.
+
+    ``extra_by_value_modules`` lets a topic script register additional shared
+    modules whose functions its predict closure calls (rarely needed — the
+    feature helpers are registered automatically).
+    """
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    by_value = [_features, _config, *extra_by_value_modules]
+    for mod in by_value:
+        cloudpickle.register_pickle_by_value(mod)
+    try:
+        tmp_path = out_path.with_suffix(out_path.suffix + ".tmp")
+        with open(tmp_path, "wb") as f:
+            cloudpickle.dump(predict_fn, f)
+        with open(tmp_path, "rb") as f:
+            pickle.load(f)              # reload check before promoting
+        os.replace(tmp_path, out_path)
+    finally:
+        for mod in by_value:
+            cloudpickle.unregister_pickle_by_value(mod)
+    return out_path

--- a/forge_models/common/features.py
+++ b/forge_models/common/features.py
@@ -1,0 +1,79 @@
+"""Stationary feature engineering shared across Forge log-return topics.
+
+IMPORTANT (deployment): the functions here are called *inside* the exported
+``predict()`` closure as well as during training. For the exported predict.pkl
+to be self-contained, ``forge_models.common.export.export_predict`` registers
+this module for pickle-by-value, so the worker process does NOT need
+``forge_models`` installed. Keep the functions here pure (only numpy/pandas +
+the constants below) so by-value pickling stays clean.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from .config import SIGMA_WINDOW, RET_LAGS, VOL_WINDOWS
+
+
+def matrices_from_workflow_df(df: pd.DataFrame, n_bars: int):
+    """Pull the kit's normalized OHLCV window back into (n, bars) matrices."""
+    cols = lambda f: [f"feature_{f}_{i}" for i in range(n_bars)]
+    C = df[cols("close")].to_numpy(dtype=float)
+    H = df[cols("high")].to_numpy(dtype=float)
+    L = df[cols("low")].to_numpy(dtype=float)
+    V = df[cols("volume")].to_numpy(dtype=float)
+    when = pd.to_datetime(df["open_time"], utc=True)
+    return C, H, L, V, when
+
+
+def compact_features(
+    C, H, L, V, when,
+    sigma_window: int = SIGMA_WINDOW,
+    ret_lags=RET_LAGS,
+    vol_windows=VOL_WINDOWS,
+):
+    """~30 stationary features per row + sigma (trailing hourly-return std).
+
+    OHLC are normalized by the window's last close, so log-return and range
+    features computed here equal those on raw prices (scale cancels). The
+    keyword defaults are bound at definition time, so they travel with the
+    function when it is pickled by value — train and inference stay identical
+    as long as the caller uses the same arguments in both places.
+    """
+    eps = 1e-12
+    B = C.shape[1]
+    logc = np.log(np.maximum(C, eps))
+    r1 = np.diff(logc, axis=1)                       # (n, B-1) per-bar log-returns
+    sw = min(sigma_window, r1.shape[1])
+    sigma = r1[:, -sw:].std(axis=1) + eps
+
+    f: dict[str, np.ndarray] = {}
+    for lag in ret_lags:
+        if lag <= B - 1:
+            f[f"ret_{lag}"] = logc[:, -1] - logc[:, -1 - lag]
+    for w in vol_windows:
+        if w <= r1.shape[1]:
+            f[f"rv_{w}"] = r1[:, -w:].std(axis=1)
+    if "rv_96" in f:
+        f["rv_ratio_6_96"] = f["rv_6"] / (f["rv_96"] + eps)
+        f["rv_ratio_24_96"] = f["rv_24"] / (f["rv_96"] + eps)
+    for lag in (1, 6, 24):                            # scale-free momentum
+        if f"ret_{lag}" in f:
+            f[f"zret_{lag}"] = f[f"ret_{lag}"] / (sigma * np.sqrt(lag))
+    g = np.clip(r1[:, -14:], 0, None).mean(axis=1)    # RSI-style balance
+    l = np.clip(-r1[:, -14:], 0, None).mean(axis=1)
+    f["rsi_14"] = 100.0 * g / (g + l + eps)
+    hi24 = H[:, -24:].max(axis=1)
+    lo24 = L[:, -24:].min(axis=1)
+    f["hl_range_24"] = hi24 - lo24                    # already in last-close units
+    f["range_pos_24"] = (C[:, -1] - lo24) / (hi24 - lo24 + eps)
+    f["vol_z_24"] = (V[:, -1] - V[:, -24:].mean(axis=1)) / (V[:, -24:].std(axis=1) + eps)
+    f["vol_trend"] = V[:, -6:].mean(axis=1) / (V[:, -48:].mean(axis=1) + eps)
+    f["sigma_100"] = sigma
+    hour = when.dt.hour.to_numpy()
+    dow = when.dt.dayofweek.to_numpy()
+    f["hour_sin"] = np.sin(2 * np.pi * hour / 24.0)
+    f["hour_cos"] = np.cos(2 * np.pi * hour / 24.0)
+    f["dow_sin"] = np.sin(2 * np.pi * dow / 7.0)
+    f["dow_cos"] = np.cos(2 * np.pi * dow / 7.0)
+    return pd.DataFrame(f, index=when.index), sigma

--- a/forge_models/train_topic_72.py
+++ b/forge_models/train_topic_72.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Topic 72 — 1h BTC/USD log-return: train / evaluate / export predict.pkl.
+
+Target (per the competition spec): log_return = ln(price_{t+1h} / price_t),
+i.e. ``target_bars=1`` at ``interval="1h"``. The exported ``predict(nonce)``
+returns the predicted **log-return as a float** — for log-return topics you
+submit the log-return itself, NOT a price.
+
+Design (v2 — built around v1's failure modes, 0-2/7 grades):
+
+* compact stationary features (~30) instead of 240 raw normalized OHLCV
+  columns — at 1h the signal-to-noise ratio is brutal and feature count is
+  variance you pay for;
+* the model learns a **vol-normalized** target z = r / sigma100 (sigma100 =
+  trailing std of the last 100 hourly log-returns, the same reference std the
+  competition's ZPTAE uses), so different regimes are comparable;
+* **recency-weighted** training (exponential half-life) instead of truncating;
+* Huber objective and a final **shrinkage calibration** (lambda) that balances
+  ZPTAE-proxy improvement against the whitelist's log-aspect-ratio bound;
+* two model families A/B'd on the same folds: a return **regressor** and a sign
+  **classifier** mapped to (2*p_up - 1) * sigma100.
+
+Shared machinery (features, calibration, data source, self-contained export)
+lives in ``forge_models/common/``; this script only holds what is specific to
+topic 72.
+
+    export ALLORA_API_KEY=UP-...
+    python forge_models/train_topic_72.py
+    # -> writes models/predict_topic_72.pkl
+
+Deploy:
+    PREDICT_PKL=models/predict_topic_72.pkl TOPIC_ID=72 \
+        python notebooks/deploy_worker.py
+
+Env knobs: DAYS_OF_HISTORY (1000), INPUT_BARS (128), HALF_LIFE_DAYS (270),
+VOL_NORM_TARGET (1; set 0 to A/B raw-target training), FAMILIES (reg,clf),
+STRICT_ASPECT (0; set 1 to always keep the whitelist aspect band),
+DATA_SOURCE (allora|binance), LIVE_CACHE_TTL (90), PREDICT_PKL.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from lightgbm import LGBMRegressor, LGBMClassifier
+from sklearn.model_selection import TimeSeriesSplit
+
+# Make `forge_models` importable whether run as a script or as a module.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from allora_forge_builder_kit import AlloraMLWorkflow, PerformanceEvaluator
+from forge_models.common import (
+    model_path, resolve_data_source,
+    matrices_from_workflow_df, compact_features,
+    zptae_proxy, aspect_ratio, tune_shrink, export_predict,
+    SIGMA_WINDOW, Z_CLIP, ASPECT_BOUND, FIXED_COMMON, REG_EXTRA,
+)
+
+# --- competition identity ---
+TOPIC_ID = 72
+INTERVAL = "1h"
+TARGET_BARS = 1                 # 1 bar ahead at 1h interval = 1 hour
+ALLORA_TICKERS = ["btcusd"]
+BINANCE_TICKERS = ["BTCUSDT"]
+
+# --- windowing / history ---
+INPUT_BARS = int(os.environ.get("INPUT_BARS", "128"))   # >=101 so sigma100 fits
+DAYS_OF_HISTORY = int(os.environ.get("DAYS_OF_HISTORY", "1000"))
+
+# --- regime handling ---
+VOL_NORM_TARGET = os.environ.get("VOL_NORM_TARGET", "1") != "0"
+HALF_LIFE_DAYS = float(os.environ.get("HALF_LIFE_DAYS", "270"))
+
+# --- model search (small, conservative grid) ---
+N_SPLITS = 3
+N_ESTIMATORS_MAX = 800
+N_ESTIMATORS_CHECKPOINTS = [200, 400, 800]
+LEARNING_RATES = [0.02, 0.05]
+MAX_DEPTHS = [3, 5]
+NUM_LEAVES = [15, 31]
+FAMILIES = tuple(os.environ.get("FAMILIES", "reg,clf").split(","))
+
+STRICT_ASPECT = os.environ.get("STRICT_ASPECT", "0") != "0"
+
+OUT_PKL = os.environ.get("PREDICT_PKL", str(model_path(TOPIC_ID)))
+
+
+def main() -> None:
+    print("=" * 78)
+    print(f"Topic {TOPIC_ID}: 1h BTC/USD log-return — train / evaluate / export (v2)")
+    print("=" * 78)
+    print(f"history={DAYS_OF_HISTORY}d  input_bars={INPUT_BARS}  "
+          f"vol_norm_target={VOL_NORM_TARGET}  half_life={HALF_LIFE_DAYS}d")
+
+    data_source, tickers, dm_kwargs = resolve_data_source(ALLORA_TICKERS, BINANCE_TICKERS)
+    workflow = AlloraMLWorkflow(
+        tickers=tickers,
+        number_of_input_bars=INPUT_BARS,
+        target_bars=TARGET_BARS,
+        interval=INTERVAL,
+        data_source=data_source,
+        **dm_kwargs,
+    )
+
+    start_date = datetime.now(timezone.utc) - timedelta(days=DAYS_OF_HISTORY)
+    print(f"\n[1/5] Backfilling {DAYS_OF_HISTORY} days of {INTERVAL} {tickers} ...")
+    try:
+        workflow.backfill(start=start_date)
+    except Exception as e:  # cached parquet may still cover us
+        print(f"  backfill warning: {e} — trying locally cached data")
+
+    print("[2/5] Building features ...")
+    df_all = workflow.get_full_feature_target_dataframe(start_date=start_date).reset_index()
+    df_all = df_all.dropna(subset=["target"]).reset_index(drop=True)
+
+    C, H, L, V, when = matrices_from_workflow_df(df_all, INPUT_BARS)
+    X, sigma100 = compact_features(C, H, L, V, when)
+    feature_cols = list(X.columns)
+    y_raw = df_all["target"].to_numpy(dtype=float)
+    y_train_space = np.clip(y_raw / sigma100, -Z_CLIP, Z_CLIP) if VOL_NORM_TARGET else y_raw
+
+    # Recency weights: a sample HALF_LIFE_DAYS old counts half as much.
+    age_days = (when.max() - when).dt.total_seconds().to_numpy() / 86400.0
+    weights = 0.5 ** (age_days / HALF_LIFE_DAYS)
+
+    print(f"  {len(X):,} samples, {len(feature_cols)} features "
+          f"({when.min()} → {when.max()})")
+
+    y_sign = (y_raw > 0).astype(int)
+
+    print("[3/5] Walk-forward grid search (selecting on calibrated ZPTAE-proxy improvement) ...")
+    tscv = TimeSeriesSplit(n_splits=N_SPLITS, gap=TARGET_BARS)
+    evaluator = PerformanceEvaluator()
+    results = []
+    n = 0
+    for family in FAMILIES:
+        for lr in LEARNING_RATES:
+            for depth in MAX_DEPTHS:
+                for leaves in NUM_LEAVES:
+                    fold_models = []
+                    for train_idx, test_idx in tscv.split(X):
+                        if family == "clf":
+                            m = LGBMClassifier(n_estimators=N_ESTIMATORS_MAX, learning_rate=lr,
+                                               max_depth=depth, num_leaves=leaves, **FIXED_COMMON)
+                            m.fit(X.iloc[train_idx], y_sign[train_idx],
+                                  sample_weight=weights[train_idx])
+                        else:
+                            m = LGBMRegressor(n_estimators=N_ESTIMATORS_MAX, learning_rate=lr,
+                                              max_depth=depth, num_leaves=leaves,
+                                              **FIXED_COMMON, **REG_EXTRA)
+                            m.fit(X.iloc[train_idx], y_train_space[train_idx],
+                                  sample_weight=weights[train_idx])
+                        fold_models.append((m, test_idx))
+                    for n_est in N_ESTIMATORS_CHECKPOINTS:
+                        n += 1
+                        pred = np.full(len(X), np.nan)
+                        for m, test_idx in fold_models:
+                            if family == "clf":
+                                p_up = m.predict_proba(X.iloc[test_idx], num_iteration=n_est)[:, 1]
+                                pred[test_idx] = 2.0 * p_up - 1.0   # conviction in [-1, 1]
+                            else:
+                                pred[test_idx] = m.predict(X.iloc[test_idx], num_iteration=n_est)
+                        mask = np.isfinite(pred)
+                        # back to log-return units before any scoring: the classifier's
+                        # conviction is always vol-scaled, the regressor only if it was
+                        # trained in z-space
+                        scale = sigma100[mask] if (family == "clf" or VOL_NORM_TARGET) else 1.0
+                        pred_lr = pred[mask] * scale
+                        lam, imp, asp = tune_shrink(y_raw[mask], pred_lr, strict_aspect=STRICT_ASPECT)
+                        da = float(np.mean(np.sign(pred_lr) == np.sign(y_raw[mask])))
+                        results.append({"family": family, "n_estimators": n_est,
+                                        "learning_rate": lr, "max_depth": depth,
+                                        "num_leaves": leaves, "lambda": lam,
+                                        "zptae_imp": imp, "aspect": asp,
+                                        "da": da, "mask": mask, "pred_lr": pred_lr})
+                        print(f"  [{family} {n:2d}] n={n_est:3d} lr={lr:.2f} d={depth} l={leaves:2d} -> "
+                              f"zptae_imp={imp:+.2%} (lam={lam:.2f}, aspect={asp:+.2f}, DA={da:.4f})")
+
+    results.sort(key=lambda r: (r["zptae_imp"], r["da"]), reverse=True)
+    for family in FAMILIES:
+        fam_best = next(r for r in results if r["family"] == family)
+        print(f"  best {family}: zptae_imp={fam_best['zptae_imp']:+.2%} DA={fam_best['da']:.4f} "
+              f"aspect={fam_best['aspect']:+.2f}")
+    best = results[0]
+    lam = best["lambda"]
+    print(f"\n[4/5] Best: family={best['family']} n={best['n_estimators']} "
+          f"lr={best['learning_rate']} d={best['max_depth']} l={best['num_leaves']} lambda={lam:.2f}")
+    print("  NOTE: lambda and config were chosen on the same OOS folds — expect the live")
+    print("  numbers to be a bit weaker. The full 7-metric report on calibrated preds:")
+    y_oos = y_raw[best["mask"]]
+    # re-run calibration verbosely once, so any score-vs-whitelist tradeoff is shown
+    tune_shrink(y_oos, best["pred_lr"], strict_aspect=STRICT_ASPECT, verbose=True)
+    p_oos = lam * best["pred_lr"]
+    report = evaluator.evaluate(y_true=pd.Series(y_oos), y_pred=pd.Series(p_oos))
+    evaluator.print_report(report, detailed=False)
+    zp_imp = best["zptae_imp"]
+    print(f"  ZPTAE proxy improvement vs zero: {zp_imp:+.2%} (whitelist target > +20%)")
+    print(f"  log-aspect ratio: {aspect_ratio(y_oos, p_oos):+.3f} (whitelist: within ±{ASPECT_BOUND})")
+
+    print("[5/5] Training production model on all data and exporting ...")
+    hp = dict(n_estimators=best["n_estimators"], learning_rate=best["learning_rate"],
+              max_depth=best["max_depth"], num_leaves=best["num_leaves"])
+    family = best["family"]
+    if family == "clf":
+        final_model = LGBMClassifier(**hp, **FIXED_COMMON)
+        final_model.fit(X, y_sign, sample_weight=weights)
+    else:
+        final_model = LGBMRegressor(**hp, **FIXED_COMMON, **REG_EXTRA)
+        final_model.fit(X, y_train_space, sample_weight=weights)
+
+    ticker = tickers[0]
+    vol_norm = VOL_NORM_TARGET
+    n_bars = INPUT_BARS
+    ds_name = data_source
+    ds_tickers = list(tickers)
+    live_ttl = float(os.environ.get("LIVE_CACHE_TTL", "90"))
+
+    # The live workflow is rebuilt lazily inside predict: data managers hold
+    # threads/locks (e.g. the Binance websocket client) that cannot be pickled,
+    # and a fresh worker process needs its own live connection anyway. Only
+    # plain config crosses the pickle boundary; the API key is re-read from the
+    # runtime environment, never embedded in the artifact. _cache is a plain
+    # dict (picklable, and cleared before export) — NOT a threading.Lock.
+    _live: dict = {"wf": None}
+    _cache: dict = {}
+
+    def _live_workflow():
+        if _live["wf"] is None:
+            import os as _os
+            from allora_forge_builder_kit import AlloraMLWorkflow as _Workflow
+            kw = {}
+            if ds_name == "allora":
+                key = _os.environ.get("ALLORA_API_KEY", "").strip()
+                if not key:
+                    for p in (".allora_api_key", "notebooks/.allora_api_key"):
+                        if _os.path.exists(p):
+                            key = open(p).read().strip()
+                            break
+                if not key:
+                    raise RuntimeError(
+                        "ALLORA_API_KEY required at inference time for the allora data source")
+                kw["api_key"] = key
+            _live["wf"] = _Workflow(
+                tickers=ds_tickers, number_of_input_bars=n_bars,
+                target_bars=TARGET_BARS, interval=INTERVAL,
+                data_source=ds_name, **kw)
+        return _live["wf"]
+
+    def predict(nonce: int | None = None) -> float:
+        """Return the predicted 1h BTC/USD **log-return** (not a price).
+
+        The SDK polls AND subscribes via websocket, so it can call predict twice
+        for the same nonce. We memoize per nonce: the second call returns the
+        identical number instantly instead of re-running a ~25s live fetch. This
+        collapses the duplicate-submission race window (the root cause of the
+        'signature verification failed' rejections) and avoids late submissions.
+        A short TTL cache of the fetched bars keeps consecutive epochs cheap too.
+        """
+        import time as _t
+        now = _t.time()
+        # Per-nonce memo: same submission round -> same prediction, instantly.
+        if nonce is not None and _cache.get("nonce") == nonce and "value" in _cache:
+            return _cache["value"]
+
+        live_row = _cache.get("data")
+        if live_row is None or (now - _cache.get("data_ts", 0.0)) > live_ttl:
+            live_row = _live_workflow().get_live_features(ticker=ticker)
+            if live_row is None or len(live_row) == 0:
+                raise ValueError("could not fetch live features")
+            live_row = live_row.reset_index()
+            if "open_time" not in live_row.columns:   # fall back to "now" for time feats
+                live_row["open_time"] = pd.Timestamp.now(tz="UTC")
+            _cache["data"] = live_row
+            _cache["data_ts"] = now
+
+        Cl, Hl, Ll, Vl, wl = matrices_from_workflow_df(live_row, n_bars)
+        X_live, sigma_live = compact_features(Cl, Hl, Ll, Vl, wl)
+        if family == "clf":
+            p_up = float(final_model.predict_proba(X_live[feature_cols])[0, 1])
+            log_ret = lam * (2.0 * p_up - 1.0) * float(sigma_live[0])
+        else:
+            raw = float(final_model.predict(X_live[feature_cols])[0])
+            log_ret = lam * raw * (float(sigma_live[0]) if vol_norm else 1.0)
+        if abs(log_ret) > 0.2:
+            print(f"warning: implausible 1h log-return {log_ret:+.4f}")
+        log_ret = float(log_ret)
+        _cache["nonce"] = nonce
+        _cache["value"] = log_ret
+        print(f"1h BTC log-return prediction (nonce={nonce}): {log_ret:+.6f}")
+        return log_ret
+
+    print("  smoke-testing predict() against live data ...")
+    test_val = predict()
+    if not np.isfinite(test_val):
+        sys.exit("predict() returned a non-finite value; not exporting")
+
+    # Drop everything the smoke test created — the live connection (often
+    # unpicklable) and the warm cache (a stale DataFrame the worker shouldn't
+    # ship with). The worker rebuilds both on first call.
+    _live["wf"] = None
+    _cache.clear()
+
+    out = export_predict(predict, OUT_PKL)
+    print(f"\nSaved {out} (topic={TOPIC_ID}, family={family}, live data via '{ds_name}').")
+    print("Deploy with your registered Forge wallet:")
+    print(f"  PREDICT_PKL={out} TOPIC_ID={TOPIC_ID} python notebooks/deploy_worker.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/forge_models/train_topic_73.py
+++ b/forge_models/train_topic_73.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Topic 73 — 1h ETH/USD log-return: train / evaluate / export predict.pkl.
+
+Same task shape as topic 72 (1h BTC/USD) — only the asset differs. Target:
+log_return = ln(price_{t+1h} / price_t), i.e. ``target_bars=1`` at
+``interval="1h"``. The exported ``predict(nonce)`` returns the predicted
+**log-return as a float** — for log-return topics you submit the log-return
+itself, NOT a price.
+
+Design (shared with topic 72 — see forge_models/README.md and common/):
+
+* compact stationary features (~30) instead of raw normalized OHLCV columns —
+  at 1h the signal-to-noise ratio is brutal and feature count is variance;
+* a **vol-normalized** target z = r / sigma100 (sigma100 = trailing std of the
+  last 100 hourly log-returns, the same reference std the ZPTAE uses);
+* **recency-weighted** training (exponential half-life);
+* Huber objective + a final **shrinkage calibration** (lambda) balancing
+  ZPTAE-proxy improvement against the whitelist log-aspect-ratio bound;
+* two families A/B'd on the same folds: a return **regressor** and a sign
+  **classifier** mapped to (2*p_up - 1) * sigma100.
+
+    export ALLORA_API_KEY=UP-...
+    python forge_models/train_topic_73.py
+    # -> writes models/predict_topic_73.pkl
+
+Deploy:
+    PREDICT_PKL=models/predict_topic_73.pkl TOPIC_ID=73 \
+        python notebooks/deploy_worker.py
+
+Env knobs: DAYS_OF_HISTORY (1000), INPUT_BARS (128), HALF_LIFE_DAYS (270),
+VOL_NORM_TARGET (1; set 0 to A/B raw-target training), FAMILIES (reg,clf),
+STRICT_ASPECT (0; set 1 to always keep the whitelist aspect band),
+DATA_SOURCE (allora|binance), LIVE_CACHE_TTL (90), PREDICT_PKL.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from lightgbm import LGBMRegressor, LGBMClassifier
+from sklearn.model_selection import TimeSeriesSplit
+
+# Make `forge_models` importable whether run as a script or as a module.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from allora_forge_builder_kit import AlloraMLWorkflow, PerformanceEvaluator
+from forge_models.common import (
+    model_path, resolve_data_source,
+    matrices_from_workflow_df, compact_features,
+    zptae_proxy, aspect_ratio, tune_shrink, export_predict,
+    SIGMA_WINDOW, Z_CLIP, ASPECT_BOUND, FIXED_COMMON, REG_EXTRA,
+)
+
+# --- competition identity ---
+TOPIC_ID = 73
+INTERVAL = "1h"
+TARGET_BARS = 1                 # 1 bar ahead at 1h interval = 1 hour
+ASSET = "ETH"
+ALLORA_TICKERS = ["ethusd"]
+BINANCE_TICKERS = ["ETHUSDT"]
+
+# --- windowing / history ---
+INPUT_BARS = int(os.environ.get("INPUT_BARS", "128"))   # >=101 so sigma100 fits
+DAYS_OF_HISTORY = int(os.environ.get("DAYS_OF_HISTORY", "1000"))
+
+# --- regime handling ---
+VOL_NORM_TARGET = os.environ.get("VOL_NORM_TARGET", "1") != "0"
+HALF_LIFE_DAYS = float(os.environ.get("HALF_LIFE_DAYS", "270"))
+
+# --- model search (small, conservative grid) ---
+N_SPLITS = 3
+N_ESTIMATORS_MAX = 800
+N_ESTIMATORS_CHECKPOINTS = [200, 400, 800]
+LEARNING_RATES = [0.02, 0.05]
+MAX_DEPTHS = [3, 5]
+NUM_LEAVES = [15, 31]
+FAMILIES = tuple(os.environ.get("FAMILIES", "reg,clf").split(","))
+
+STRICT_ASPECT = os.environ.get("STRICT_ASPECT", "0") != "0"
+
+OUT_PKL = os.environ.get("PREDICT_PKL", str(model_path(TOPIC_ID)))
+
+
+def main() -> None:
+    print("=" * 78)
+    print(f"Topic {TOPIC_ID}: 1h {ASSET}/USD log-return — train / evaluate / export (v2)")
+    print("=" * 78)
+    print(f"history={DAYS_OF_HISTORY}d  input_bars={INPUT_BARS}  "
+          f"vol_norm_target={VOL_NORM_TARGET}  half_life={HALF_LIFE_DAYS}d")
+
+    data_source, tickers, dm_kwargs = resolve_data_source(ALLORA_TICKERS, BINANCE_TICKERS)
+    workflow = AlloraMLWorkflow(
+        tickers=tickers,
+        number_of_input_bars=INPUT_BARS,
+        target_bars=TARGET_BARS,
+        interval=INTERVAL,
+        data_source=data_source,
+        **dm_kwargs,
+    )
+
+    start_date = datetime.now(timezone.utc) - timedelta(days=DAYS_OF_HISTORY)
+    print(f"\n[1/5] Backfilling {DAYS_OF_HISTORY} days of {INTERVAL} {tickers} ...")
+    try:
+        workflow.backfill(start=start_date)
+    except Exception as e:  # cached parquet may still cover us
+        print(f"  backfill warning: {e} — trying locally cached data")
+
+    print("[2/5] Building features ...")
+    df_all = workflow.get_full_feature_target_dataframe(start_date=start_date).reset_index()
+    df_all = df_all.dropna(subset=["target"]).reset_index(drop=True)
+
+    C, H, L, V, when = matrices_from_workflow_df(df_all, INPUT_BARS)
+    X, sigma100 = compact_features(C, H, L, V, when)
+    feature_cols = list(X.columns)
+    y_raw = df_all["target"].to_numpy(dtype=float)
+    y_train_space = np.clip(y_raw / sigma100, -Z_CLIP, Z_CLIP) if VOL_NORM_TARGET else y_raw
+
+    # Recency weights: a sample HALF_LIFE_DAYS old counts half as much.
+    age_days = (when.max() - when).dt.total_seconds().to_numpy() / 86400.0
+    weights = 0.5 ** (age_days / HALF_LIFE_DAYS)
+
+    print(f"  {len(X):,} samples, {len(feature_cols)} features "
+          f"({when.min()} → {when.max()})")
+
+    y_sign = (y_raw > 0).astype(int)
+
+    print("[3/5] Walk-forward grid search (selecting on calibrated ZPTAE-proxy improvement) ...")
+    tscv = TimeSeriesSplit(n_splits=N_SPLITS, gap=TARGET_BARS)
+    evaluator = PerformanceEvaluator()
+    results = []
+    n = 0
+    for family in FAMILIES:
+        for lr in LEARNING_RATES:
+            for depth in MAX_DEPTHS:
+                for leaves in NUM_LEAVES:
+                    fold_models = []
+                    for train_idx, test_idx in tscv.split(X):
+                        if family == "clf":
+                            m = LGBMClassifier(n_estimators=N_ESTIMATORS_MAX, learning_rate=lr,
+                                               max_depth=depth, num_leaves=leaves, **FIXED_COMMON)
+                            m.fit(X.iloc[train_idx], y_sign[train_idx],
+                                  sample_weight=weights[train_idx])
+                        else:
+                            m = LGBMRegressor(n_estimators=N_ESTIMATORS_MAX, learning_rate=lr,
+                                              max_depth=depth, num_leaves=leaves,
+                                              **FIXED_COMMON, **REG_EXTRA)
+                            m.fit(X.iloc[train_idx], y_train_space[train_idx],
+                                  sample_weight=weights[train_idx])
+                        fold_models.append((m, test_idx))
+                    for n_est in N_ESTIMATORS_CHECKPOINTS:
+                        n += 1
+                        pred = np.full(len(X), np.nan)
+                        for m, test_idx in fold_models:
+                            if family == "clf":
+                                p_up = m.predict_proba(X.iloc[test_idx], num_iteration=n_est)[:, 1]
+                                pred[test_idx] = 2.0 * p_up - 1.0   # conviction in [-1, 1]
+                            else:
+                                pred[test_idx] = m.predict(X.iloc[test_idx], num_iteration=n_est)
+                        mask = np.isfinite(pred)
+                        # back to log-return units before any scoring: the classifier's
+                        # conviction is always vol-scaled, the regressor only if it was
+                        # trained in z-space
+                        scale = sigma100[mask] if (family == "clf" or VOL_NORM_TARGET) else 1.0
+                        pred_lr = pred[mask] * scale
+                        lam, imp, asp = tune_shrink(y_raw[mask], pred_lr, strict_aspect=STRICT_ASPECT)
+                        da = float(np.mean(np.sign(pred_lr) == np.sign(y_raw[mask])))
+                        results.append({"family": family, "n_estimators": n_est,
+                                        "learning_rate": lr, "max_depth": depth,
+                                        "num_leaves": leaves, "lambda": lam,
+                                        "zptae_imp": imp, "aspect": asp,
+                                        "da": da, "mask": mask, "pred_lr": pred_lr})
+                        print(f"  [{family} {n:2d}] n={n_est:3d} lr={lr:.2f} d={depth} l={leaves:2d} -> "
+                              f"zptae_imp={imp:+.2%} (lam={lam:.2f}, aspect={asp:+.2f}, DA={da:.4f})")
+
+    results.sort(key=lambda r: (r["zptae_imp"], r["da"]), reverse=True)
+    for family in FAMILIES:
+        fam_best = next(r for r in results if r["family"] == family)
+        print(f"  best {family}: zptae_imp={fam_best['zptae_imp']:+.2%} DA={fam_best['da']:.4f} "
+              f"aspect={fam_best['aspect']:+.2f}")
+    best = results[0]
+    lam = best["lambda"]
+    print(f"\n[4/5] Best: family={best['family']} n={best['n_estimators']} "
+          f"lr={best['learning_rate']} d={best['max_depth']} l={best['num_leaves']} lambda={lam:.2f}")
+    print("  NOTE: lambda and config were chosen on the same OOS folds — expect the live")
+    print("  numbers to be a bit weaker. The full 7-metric report on calibrated preds:")
+    y_oos = y_raw[best["mask"]]
+    # re-run calibration verbosely once, so any score-vs-whitelist tradeoff is shown
+    tune_shrink(y_oos, best["pred_lr"], strict_aspect=STRICT_ASPECT, verbose=True)
+    p_oos = lam * best["pred_lr"]
+    report = evaluator.evaluate(y_true=pd.Series(y_oos), y_pred=pd.Series(p_oos))
+    evaluator.print_report(report, detailed=False)
+    zp_imp = best["zptae_imp"]
+    print(f"  ZPTAE proxy improvement vs zero: {zp_imp:+.2%} (whitelist target > +20%)")
+    print(f"  log-aspect ratio: {aspect_ratio(y_oos, p_oos):+.3f} (whitelist: within ±{ASPECT_BOUND})")
+
+    print("[5/5] Training production model on all data and exporting ...")
+    hp = dict(n_estimators=best["n_estimators"], learning_rate=best["learning_rate"],
+              max_depth=best["max_depth"], num_leaves=best["num_leaves"])
+    family = best["family"]
+    if family == "clf":
+        final_model = LGBMClassifier(**hp, **FIXED_COMMON)
+        final_model.fit(X, y_sign, sample_weight=weights)
+    else:
+        final_model = LGBMRegressor(**hp, **FIXED_COMMON, **REG_EXTRA)
+        final_model.fit(X, y_train_space, sample_weight=weights)
+
+    ticker = tickers[0]
+    vol_norm = VOL_NORM_TARGET
+    n_bars = INPUT_BARS
+    ds_name = data_source
+    ds_tickers = list(tickers)
+    asset = ASSET
+    live_ttl = float(os.environ.get("LIVE_CACHE_TTL", "90"))
+
+    # The live workflow is rebuilt lazily inside predict: data managers hold
+    # threads/locks (e.g. the Binance websocket client) that cannot be pickled,
+    # and a fresh worker process needs its own live connection anyway. Only
+    # plain config crosses the pickle boundary; the API key is re-read from the
+    # runtime environment, never embedded in the artifact. _cache is a plain
+    # dict (picklable, and cleared before export) — NOT a threading.Lock.
+    _live: dict = {"wf": None}
+    _cache: dict = {}
+
+    def _live_workflow():
+        if _live["wf"] is None:
+            import os as _os
+            from allora_forge_builder_kit import AlloraMLWorkflow as _Workflow
+            kw = {}
+            if ds_name == "allora":
+                key = _os.environ.get("ALLORA_API_KEY", "").strip()
+                if not key:
+                    for p in (".allora_api_key", "notebooks/.allora_api_key"):
+                        if _os.path.exists(p):
+                            key = open(p).read().strip()
+                            break
+                if not key:
+                    raise RuntimeError(
+                        "ALLORA_API_KEY required at inference time for the allora data source")
+                kw["api_key"] = key
+            _live["wf"] = _Workflow(
+                tickers=ds_tickers, number_of_input_bars=n_bars,
+                target_bars=TARGET_BARS, interval=INTERVAL,
+                data_source=ds_name, **kw)
+        return _live["wf"]
+
+    def predict(nonce: int | None = None) -> float:
+        """Return the predicted 1h ETH/USD **log-return** (not a price).
+
+        The SDK polls AND subscribes via websocket, so it can call predict twice
+        for the same nonce. We memoize per nonce: the second call returns the
+        identical number instantly instead of re-running a ~25s live fetch. This
+        collapses the duplicate-submission race window (the root cause of the
+        'signature verification failed' rejections) and avoids late submissions.
+        A short TTL cache of the fetched bars keeps consecutive epochs cheap too.
+        """
+        import time as _t
+        now = _t.time()
+        # Per-nonce memo: same submission round -> same prediction, instantly.
+        if nonce is not None and _cache.get("nonce") == nonce and "value" in _cache:
+            return _cache["value"]
+
+        live_row = _cache.get("data")
+        if live_row is None or (now - _cache.get("data_ts", 0.0)) > live_ttl:
+            live_row = _live_workflow().get_live_features(ticker=ticker)
+            if live_row is None or len(live_row) == 0:
+                raise ValueError("could not fetch live features")
+            live_row = live_row.reset_index()
+            if "open_time" not in live_row.columns:   # fall back to "now" for time feats
+                live_row["open_time"] = pd.Timestamp.now(tz="UTC")
+            _cache["data"] = live_row
+            _cache["data_ts"] = now
+
+        Cl, Hl, Ll, Vl, wl = matrices_from_workflow_df(live_row, n_bars)
+        X_live, sigma_live = compact_features(Cl, Hl, Ll, Vl, wl)
+        if family == "clf":
+            p_up = float(final_model.predict_proba(X_live[feature_cols])[0, 1])
+            log_ret = lam * (2.0 * p_up - 1.0) * float(sigma_live[0])
+        else:
+            raw = float(final_model.predict(X_live[feature_cols])[0])
+            log_ret = lam * raw * (float(sigma_live[0]) if vol_norm else 1.0)
+        if abs(log_ret) > 0.2:
+            print(f"warning: implausible 1h log-return {log_ret:+.4f}")
+        log_ret = float(log_ret)
+        _cache["nonce"] = nonce
+        _cache["value"] = log_ret
+        print(f"1h {asset} log-return prediction (nonce={nonce}): {log_ret:+.6f}")
+        return log_ret
+
+    print("  smoke-testing predict() against live data ...")
+    test_val = predict()
+    if not np.isfinite(test_val):
+        sys.exit("predict() returned a non-finite value; not exporting")
+
+    # Drop everything the smoke test created — the live connection (often
+    # unpicklable) and the warm cache (a stale DataFrame the worker shouldn't
+    # ship with). The worker rebuilds both on first call.
+    _live["wf"] = None
+    _cache.clear()
+
+    out = export_predict(predict, OUT_PKL)
+    print(f"\nSaved {out} (topic={TOPIC_ID}, family={family}, live data via '{ds_name}').")
+    print("Deploy with your registered Forge wallet:")
+    print(f"  PREDICT_PKL={out} TOPIC_ID={TOPIC_ID} python notebooks/deploy_worker.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/.gitkeep
+++ b/models/.gitkeep
@@ -1,0 +1,2 @@
+# Trained Forge model artifacts land here as predict_topic_<id>.pkl.
+# The .pkl files themselves are git-ignored; this keeps the folder in git.

--- a/notebooks/deploy_worker.py
+++ b/notebooks/deploy_worker.py
@@ -29,10 +29,21 @@ def main():
             "  python notebooks/example_topic_77_bitcoin_5min_walkthrough.py"
         )
 
+    mnemonic = os.environ.get("MNEMONIC", "").strip() or None
+    address = os.environ.get("WALLET_ADDRESS", "").strip() or None
+
+    if mnemonic and not address:
+        raise ValueError("WALLET_ADDRESS must be set when MNEMONIC is provided")
+
     wm = WorkerManager()
 
     print(f"Deploying worker for Topic {topic_id}...")
-    result = wm.deploy_worker(topic_id=topic_id, artifact_path=artifact)
+    result = wm.deploy_worker(
+        topic_id=topic_id,
+        artifact_path=artifact,
+        mnemonic=mnemonic,
+        address=address,
+    )
     print(f"  {result.message}")
     print(f"  Address: {result.address_assigned}")
 


### PR DESCRIPTION
  ## Summary
  Adds `forge_models/` as a single home for per-competition Allora Forge training
  scripts, backed by a shared `common/` library so each topic script stays thin.

  - common/ — features, ZPTAE-proxy calibration/shrinkage, data-source resolution,
    and an atomic self-contained export_predict() (cloudpickle pickle-by-value).
  - train_topic_72.py — 1h BTC/USD log-return (ported from the v2 script).
  - train_topic_73.py — 1h ETH/USD log-return (same task, asset swapped).

  Scripts write models/predict_topic_<id>.pkl (.pkl git-ignored; folder kept via .gitkeep).

  ## Why the shared library is deploy-safe
  export_predict() registers the shared modules for pickle-by-value, so the artifact
  carries its code — the worker doesn't need forge_models installed. Verified with a
  round-trip test loading the pkl in a subprocess where forge_models was confirmed
  not importable; predict() reproduced the value exactly.

  ## Notes
  - Training not run here (needs ALLORA_API_KEY + network); all modules compile.
  - Confirm the Allora/Tiingo `ethusd` symbol on the first topic-73 backfill.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies Allora Forge training under `forge_models/` with a shared `common/` library and adds topic 72 (BTC) and 73 (ETH) 1h log-return scripts that export self-contained `predict.pkl` artifacts. Also allows deploying with an existing wallet via `MNEMONIC` and `WALLET_ADDRESS`.

- **New Features**
  - Added `forge_models/common/` with shared `features`, `calibration`, `data` helpers, plus atomic `export_predict()` that uses `cloudpickle` pickle-by-value so workers don’t need `forge_models` installed.
  - Added `train_topic_72.py` and `train_topic_73.py`: compact stationary features, vol-normalized targets, recency-weighted `lightgbm` (regressor/classifier A/B), shrinkage calibration; outputs `models/predict_topic_<id>.pkl`.
  - Updated `notebooks/deploy_worker.py` to accept `MNEMONIC` and `WALLET_ADDRESS` for bring-your-own wallet.

- **Migration**
  - Train and export: set `ALLORA_API_KEY` (or `DATA_SOURCE=binance`) and run `python forge_models/train_topic_72.py` or `python forge_models/train_topic_73.py`.
  - Deploy: set `PREDICT_PKL=models/predict_topic_<id>.pkl` and `TOPIC_ID=<id>`, then run `python notebooks/deploy_worker.py`.
  - Optional wallet: set both `MNEMONIC` and `WALLET_ADDRESS` to deploy with your own keys (both are required together).

<sup>Written for commit 10a896948f62e68ef977e772cc57066804051c82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-forge-builder-kit/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

