### PR TITLE
feat: --custody managed + local SDK pin for ENGN-8646 testing

### DIFF
--- a/allora_forge_builder_kit/worker_runtime.py
+++ b/allora_forge_builder_kit/worker_runtime.py
@@ -37,16 +37,28 @@ def _build_network(network: str, no_faucet: bool) -> AlloraNetworkConfig:
     return cfg
 
 
+def _resolve_wallet_cfg(custody: str, mnemonic_file: str | None) -> AlloraWalletConfig | None:
+    """Resolve the signing-wallet config for the chosen custody mode.
+
+    Managed custody runs ``AlloraWalletConfig.from_env()``, which performs a blocking wallet-info
+    fetch. It is resolved here in sync code (called from ``main`` before the event loop starts) so
+    the blocking I/O and any startup failure surface before ``asyncio.run`` rather than stalling
+    the running event loop.
+    """
+    if custody == "managed":
+        return AlloraWalletConfig.from_env()
+    return AlloraWalletConfig(mnemonic_file=mnemonic_file) if mnemonic_file else None
+
+
 async def _run(
     topic_id: int,
     artifact_path: str,
     api_key: str,
-    mnemonic_file: str | None = None,
+    wallet_cfg: AlloraWalletConfig | None = None,
     network: str = "testnet",
     no_faucet: bool = False,
     debug: bool = False,
     reject_zero: bool = False,
-    custody: str = "local",
 ) -> None:
     with open(artifact_path, "rb") as f:
         raw_fn = cloudpickle.load(f)
@@ -65,14 +77,6 @@ async def _run(
             raise RuntimeError("Invalid inference output: zero value rejected for price topic")
         return v
 
-    if custody == "managed":
-        # Privy-managed custody: from_env() reads FORGE_API_KEY (+ optional FEE_GRANTER) and,
-        # with no FORGE_SIGNING_WALLET_ID, defers wallet provisioning to the worker — which
-        # get-or-creates a managed wallet bound to this topic at startup (ENGN-8646). No local
-        # key file is created.
-        wallet_cfg = AlloraWalletConfig.from_env()
-    else:
-        wallet_cfg = AlloraWalletConfig(mnemonic_file=mnemonic_file) if mnemonic_file else None
     net_cfg = _build_network(network, no_faucet)
     worker = AlloraWorker.inferer(
         run=run_fn,
@@ -106,16 +110,16 @@ def main() -> None:
     args = parser.parse_args()
 
     api_key = _load_api_key(args.api_key)
+    wallet_cfg = _resolve_wallet_cfg(args.custody, args.mnemonic_file)
     asyncio.run(_run(
         topic_id=args.topic,
         artifact_path=args.artifact,
         api_key=api_key,
-        mnemonic_file=args.mnemonic_file,
+        wallet_cfg=wallet_cfg,
         network=args.network,
         no_faucet=args.no_faucet,
         debug=args.debug,
         reject_zero=args.reject_zero,
-        custody=args.custody,
     ))
 
 

--- a/allora_forge_builder_kit/worker_runtime.py
+++ b/allora_forge_builder_kit/worker_runtime.py
@@ -1,3 +1,14 @@
+"""Run an Allora worker from a pickled inference artifact.
+
+Two distinct API keys are used here and must not be confused:
+
+- ``ALLORA_API_KEY`` (``--api-key``): the Allora consumer/faucet key the kit uses for testnet
+  faucet drips and topic queries (see ``_load_api_key``).
+- ``FORGE_API_KEY``: the Forge backend key the SDK's ``AlloraWalletConfig.from_env()`` reads under
+  ``--custody managed`` to provision and sign with a Privy-managed wallet.
+
+They authenticate different backends; ``--custody managed`` consumes ``FORGE_API_KEY`` only.
+"""
 from __future__ import annotations
 
 import argparse

--- a/allora_forge_builder_kit/worker_runtime.py
+++ b/allora_forge_builder_kit/worker_runtime.py
@@ -5,6 +5,7 @@ import asyncio
 import inspect
 import math
 import os
+import warnings
 from typing import TYPE_CHECKING, Callable, Literal
 
 import cloudpickle
@@ -159,6 +160,13 @@ def main() -> None:
         parser.error(
             "--custody managed requires FORGE_API_KEY in the environment "
             "(the SDK provisions a topic-bound managed wallet from it)"
+        )
+
+    if args.custody == "managed" and not os.environ.get("FEE_GRANTER"):
+        warnings.warn(
+            "FEE_GRANTER is not set: a managed wallet holds no ALLO, so gasless submission needs "
+            "a fee granter — transactions may fail with 'insufficient fees' without one.",
+            stacklevel=2,
         )
 
     api_key = _load_api_key(args.api_key)

--- a/allora_forge_builder_kit/worker_runtime.py
+++ b/allora_forge_builder_kit/worker_runtime.py
@@ -5,12 +5,15 @@ import asyncio
 import inspect
 import math
 import os
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 import cloudpickle
 
 from allora_sdk.worker import AlloraWorker
 from allora_sdk.rpc_client.config import AlloraNetworkConfig, AlloraWalletConfig
+
+if TYPE_CHECKING:
+    from allora_sdk.worker.context import RunContext
 
 
 def _load_api_key(explicit: str | None) -> str:
@@ -95,7 +98,7 @@ async def _run(
         raw_fn = cloudpickle.load(f)
     expects_context = _artifact_expects_context(raw_fn)
 
-    def run_fn(ctx):
+    def run_fn(ctx: RunContext) -> float:
         # Legacy artifacts take the integer nonce (raw_fn(ctx.nonce)); newer artifacts take the
         # RunContext itself. The call shape is resolved once above to avoid per-nonce introspection.
         value = raw_fn(ctx) if expects_context else raw_fn(ctx.nonce)

--- a/allora_forge_builder_kit/worker_runtime.py
+++ b/allora_forge_builder_kit/worker_runtime.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import inspect
 import math
 import os
+from typing import Callable
+
 import cloudpickle
 
 from allora_sdk.worker import AlloraWorker
@@ -50,6 +53,28 @@ def _resolve_wallet_cfg(custody: str, mnemonic_file: str | None) -> AlloraWallet
     return AlloraWalletConfig(mnemonic_file=mnemonic_file) if mnemonic_file else None
 
 
+def _artifact_expects_context(raw_fn: Callable[..., object]) -> bool:
+    """Return True when a pickled artifact follows the SDK's RunContext call contract.
+
+    Legacy kit artifacts are written as ``fn(nonce: int)``; the current SDK invokes the inferer
+    callback with a ``RunContext``. Default to the legacy nonce form and only pass the
+    ``RunContext`` when the artifact's single positional parameter is annotated as — or named
+    like — a context, preserving back-compat for the overwhelmingly common legacy artifacts.
+    """
+    try:
+        params = [
+            p
+            for p in inspect.signature(raw_fn).parameters.values()
+            if p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        ]
+    except (TypeError, ValueError):
+        return False
+    if len(params) != 1:
+        return False
+    annotation = "" if params[0].annotation is inspect.Parameter.empty else str(params[0].annotation)
+    return "RunContext" in annotation or params[0].name in ("ctx", "context", "run_context")
+
+
 async def _run(
     topic_id: int,
     artifact_path: str,
@@ -60,13 +85,20 @@ async def _run(
     debug: bool = False,
     reject_zero: bool = False,
 ) -> None:
+    """Load the pickled inference artifact and drive the worker submission loop.
+
+    Artifact contract: the pickled callable is invoked as ``fn(nonce: int)`` and must return a
+    finite numeric value. Artifacts written to the newer SDK contract (``fn(ctx)`` taking a
+    ``RunContext``) are also supported; the call shape is detected once at load time.
+    """
     with open(artifact_path, "rb") as f:
         raw_fn = cloudpickle.load(f)
+    expects_context = _artifact_expects_context(raw_fn)
 
     def run_fn(ctx):
-        # The branch SDK invokes the inferer fn with a RunContext; the pickled model fn
-        # still takes the integer nonce, so adapt via ctx.nonce.
-        value = raw_fn(ctx.nonce)
+        # Legacy artifacts take the integer nonce (raw_fn(ctx.nonce)); newer artifacts take the
+        # RunContext itself. The call shape is resolved once above to avoid per-nonce introspection.
+        value = raw_fn(ctx) if expects_context else raw_fn(ctx.nonce)
         try:
             v = float(value)
         except Exception as e:

--- a/allora_forge_builder_kit/worker_runtime.py
+++ b/allora_forge_builder_kit/worker_runtime.py
@@ -46,12 +46,15 @@ async def _run(
     no_faucet: bool = False,
     debug: bool = False,
     reject_zero: bool = False,
+    custody: str = "local",
 ) -> None:
     with open(artifact_path, "rb") as f:
         raw_fn = cloudpickle.load(f)
 
-    def run_fn(nonce: int):
-        value = raw_fn(nonce)
+    def run_fn(ctx):
+        # The branch SDK invokes the inferer fn with a RunContext; the pickled model fn
+        # still takes the integer nonce, so adapt via ctx.nonce.
+        value = raw_fn(ctx.nonce)
         try:
             v = float(value)
         except Exception as e:
@@ -62,9 +65,23 @@ async def _run(
             raise RuntimeError("Invalid inference output: zero value rejected for price topic")
         return v
 
-    wallet_cfg = AlloraWalletConfig(mnemonic_file=mnemonic_file) if mnemonic_file else None
+    if custody == "managed":
+        # Privy-managed custody: from_env() reads FORGE_API_KEY (+ optional FEE_GRANTER) and,
+        # with no FORGE_SIGNING_WALLET_ID, defers wallet provisioning to the worker — which
+        # get-or-creates a managed wallet bound to this topic at startup (ENGN-8646). No local
+        # key file is created.
+        wallet_cfg = AlloraWalletConfig.from_env()
+    else:
+        wallet_cfg = AlloraWalletConfig(mnemonic_file=mnemonic_file) if mnemonic_file else None
     net_cfg = _build_network(network, no_faucet)
-    worker = AlloraWorker(run=run_fn, topic_id=topic_id, api_key=api_key, wallet=wallet_cfg, network=net_cfg, debug=debug)
+    worker = AlloraWorker.inferer(
+        run=run_fn,
+        wallet=wallet_cfg,
+        network=net_cfg,
+        api_key=api_key,
+        topic_id=topic_id,
+        debug=debug,
+    )
     async for _ in worker.run():
         pass
 
@@ -77,6 +94,13 @@ def main() -> None:
     parser.add_argument("--mnemonic-file", default=None, help="Path to wallet key file (managed by WorkerManager)")
     parser.add_argument("--network", default="testnet", choices=["testnet", "mainnet"])
     parser.add_argument("--no-faucet", action="store_true", help="Skip SDK faucet checks (use when already funded)")
+    parser.add_argument(
+        "--custody",
+        choices=["local", "managed"],
+        default="local",
+        help="Wallet custody: 'local' (self-custodial key file) or 'managed' (Privy-managed; "
+        "provisions a wallet bound to the topic via FORGE_API_KEY, no local key)",
+    )
     parser.add_argument("--debug", action="store_true")
     parser.add_argument("--reject-zero", action="store_true")
     args = parser.parse_args()
@@ -91,6 +115,7 @@ def main() -> None:
         no_faucet=args.no_faucet,
         debug=args.debug,
         reject_zero=args.reject_zero,
+        custody=args.custody,
     ))
 
 

--- a/allora_forge_builder_kit/worker_runtime.py
+++ b/allora_forge_builder_kit/worker_runtime.py
@@ -146,6 +146,12 @@ def main() -> None:
     parser.add_argument("--reject-zero", action="store_true")
     args = parser.parse_args()
 
+    if args.custody == "managed" and args.mnemonic_file:
+        parser.error(
+            "--mnemonic-file is incompatible with --custody managed; managed custody uses "
+            "FORGE_API_KEY from the environment"
+        )
+
     api_key = _load_api_key(args.api_key)
     wallet_cfg = _resolve_wallet_cfg(args.custody, args.mnemonic_file)
     asyncio.run(_run(

--- a/allora_forge_builder_kit/worker_runtime.py
+++ b/allora_forge_builder_kit/worker_runtime.py
@@ -48,10 +48,13 @@ def _resolve_wallet_cfg(
 ) -> AlloraWalletConfig | None:
     """Resolve the signing-wallet config for the chosen custody mode.
 
-    Managed custody runs ``AlloraWalletConfig.from_env()``, which performs a blocking wallet-info
-    fetch. It is resolved here in sync code (called from ``main`` before the event loop starts) so
-    the blocking I/O and any startup failure surface before ``asyncio.run`` rather than stalling
-    the running event loop.
+    Managed custody runs ``AlloraWalletConfig.from_env()``. With ``FORGE_API_KEY`` set and no
+    ``FORGE_SIGNING_WALLET_ID``, the SDK returns a deferred managed config (no local key) and the
+    worker get-or-creates a wallet bound to its topic at startup (ENGN-8646). The managed branch is
+    taken before any ``PRIVATE_KEY`` / ``MNEMONIC`` is read, so ``FORGE_API_KEY`` always takes
+    precedence — there is no silent local-key fallback. ``from_env()`` performs a blocking
+    wallet-info fetch, so it is resolved here in sync code (called from ``main`` before the event
+    loop starts) rather than inside the async worker.
     """
     if custody == "managed":
         return AlloraWalletConfig.from_env()
@@ -150,6 +153,12 @@ def main() -> None:
         parser.error(
             "--mnemonic-file is incompatible with --custody managed; managed custody uses "
             "FORGE_API_KEY from the environment"
+        )
+
+    if args.custody == "managed" and not os.environ.get("FORGE_API_KEY"):
+        parser.error(
+            "--custody managed requires FORGE_API_KEY in the environment "
+            "(the SDK provisions a topic-bound managed wallet from it)"
         )
 
     api_key = _load_api_key(args.api_key)

--- a/allora_forge_builder_kit/worker_runtime.py
+++ b/allora_forge_builder_kit/worker_runtime.py
@@ -5,7 +5,7 @@ import asyncio
 import inspect
 import math
 import os
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, Literal
 
 import cloudpickle
 
@@ -43,7 +43,9 @@ def _build_network(network: str, no_faucet: bool) -> AlloraNetworkConfig:
     return cfg
 
 
-def _resolve_wallet_cfg(custody: str, mnemonic_file: str | None) -> AlloraWalletConfig | None:
+def _resolve_wallet_cfg(
+    custody: Literal["local", "managed"], mnemonic_file: str | None
+) -> AlloraWalletConfig | None:
     """Resolve the signing-wallet config for the chosen custody mode.
 
     Managed custody runs ``AlloraWalletConfig.from_env()``, which performs a blocking wallet-info

--- a/notebooks/deploy_worker_raw.py
+++ b/notebooks/deploy_worker_raw.py
@@ -9,7 +9,8 @@ Useful as a reference or for quick one-off deployments.
 For production use, see deploy_worker.py which uses WorkerManager for
 wallet creation, faucet funding, process management, and the web dashboard.
 
-Compatible with allora_sdk >= 1.0.6.
+Targets the branch allora_sdk worker API (AlloraWorker.inferer + a RunContext-based
+run fn), matching worker_runtime.py.
 """
 
 import os
@@ -50,12 +51,18 @@ if not api_key:
     )
 
 
+def _run_fn(ctx):
+    # The branch SDK invokes the inferer callback with a RunContext; the pickled model fn
+    # takes the integer nonce, so adapt via ctx.nonce.
+    return predict_fn(ctx.nonce)
+
+
 async def main():
     """Run the Allora worker with the trained model."""
     print(f"\nStarting Allora worker for Topic {TOPIC_ID}...")
 
-    worker = AlloraWorker(
-        run=predict_fn,
+    worker = AlloraWorker.inferer(
+        run=_run_fn,
         topic_id=TOPIC_ID,
         api_key=api_key,
         debug=DEBUG_MODE,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,12 @@ Homepage = "https://github.com/allora-network/allora-forge-builder-kit"
 
 [tool.setuptools.packages.find]
 include = ["allora_forge_builder_kit"]
+
+# --- LOCAL-DEV PIN for ENGN-8646 (managed-wallet auto-provision) testing ONLY ---
+# Points allora-sdk at the local branch worktree, which carries the unreleased
+# provision / topic-bound auto-provision changes (plus its generated protobuf code).
+# uv picks this up on `uv sync` / `uv run`. REMOVE this block and bump the
+# `allora-sdk` version in [project].dependencies once the SDK release with ENGN-8646
+# ships; the relative path assumes the allora-sdk-py worktree is a sibling directory.
+[tool.uv.sources]
+allora-sdk = { path = "../allora-sdk-py", editable = true }

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1,4 +1,13 @@
-from allora_forge_builder_kit.worker_runtime import _build_network, _TESTNET_FAUCET_URL
+import pytest
+
+from allora_forge_builder_kit import worker_runtime
+from allora_forge_builder_kit.worker_runtime import (
+    _TESTNET_FAUCET_URL,
+    _artifact_expects_context,
+    _build_network,
+    _resolve_wallet_cfg,
+    main,
+)
 
 
 def test_build_network_testnet_overrides_faucet_url():
@@ -15,3 +24,110 @@ def test_build_network_no_faucet_clears_url():
     for network in ("testnet", "mainnet"):
         cfg = _build_network(network, no_faucet=True)
         assert cfg.faucet_url is None
+
+
+class _FakeWalletConfig:
+    """Stand-in for AlloraWalletConfig that records how it is constructed/invoked."""
+
+    last_init_kwargs: dict | None = None
+    from_env_calls: int = 0
+    from_env_sentinel = object()
+
+    def __init__(self, **kwargs):
+        type(self).last_init_kwargs = kwargs
+
+    @classmethod
+    def from_env(cls):
+        cls.from_env_calls += 1
+        return cls.from_env_sentinel
+
+
+@pytest.fixture
+def fake_wallet_config(monkeypatch):
+    _FakeWalletConfig.last_init_kwargs = None
+    _FakeWalletConfig.from_env_calls = 0
+    monkeypatch.setattr(worker_runtime, "AlloraWalletConfig", _FakeWalletConfig)
+    return _FakeWalletConfig
+
+
+def test_resolve_wallet_cfg_managed_calls_from_env(fake_wallet_config):
+    cfg = _resolve_wallet_cfg("managed", None)
+    assert cfg is fake_wallet_config.from_env_sentinel
+    assert fake_wallet_config.from_env_calls == 1
+    # Managed routing must not construct a local AlloraWalletConfig(...).
+    assert fake_wallet_config.last_init_kwargs is None
+
+
+def test_resolve_wallet_cfg_managed_ignores_mnemonic_file(fake_wallet_config):
+    cfg = _resolve_wallet_cfg("managed", "/tmp/key.txt")
+    assert cfg is fake_wallet_config.from_env_sentinel
+    assert fake_wallet_config.last_init_kwargs is None
+
+
+def test_resolve_wallet_cfg_local_builds_from_mnemonic_file(fake_wallet_config):
+    _resolve_wallet_cfg("local", "/tmp/key.txt")
+    assert fake_wallet_config.from_env_calls == 0
+    assert fake_wallet_config.last_init_kwargs == {"mnemonic_file": "/tmp/key.txt"}
+
+
+def test_resolve_wallet_cfg_local_without_mnemonic_is_none(fake_wallet_config):
+    assert _resolve_wallet_cfg("local", None) is None
+    assert fake_wallet_config.from_env_calls == 0
+
+
+def test_main_managed_with_mnemonic_file_errors(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "worker_runtime",
+            "--topic", "1",
+            "--artifact", "x.pkl",
+            "--custody", "managed",
+            "--mnemonic-file", "k.txt",
+        ],
+    )
+    monkeypatch.setenv("FORGE_API_KEY", "fk")
+    with pytest.raises(SystemExit):
+        main()
+
+
+def test_main_managed_without_forge_api_key_errors(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        ["worker_runtime", "--topic", "1", "--artifact", "x.pkl", "--custody", "managed"],
+    )
+    monkeypatch.delenv("FORGE_API_KEY", raising=False)
+    with pytest.raises(SystemExit):
+        main()
+
+
+def test_artifact_expects_context_legacy_nonce():
+    def legacy(nonce):
+        return 1.0
+
+    assert _artifact_expects_context(legacy) is False
+
+
+def test_artifact_expects_context_runcontext_by_name():
+    def modern(ctx):
+        return 1.0
+
+    assert _artifact_expects_context(modern) is True
+
+
+def test_artifact_expects_context_runcontext_by_annotation():
+    def modern(x: "RunContext"):  # noqa: F821 - forward ref string is the point
+        return 1.0
+
+    assert _artifact_expects_context(modern) is True
+
+
+def test_artifact_expects_context_multiarg_defaults_false():
+    def two(a, b):
+        return 1.0
+
+    assert _artifact_expects_context(two) is False
+
+
+def test_artifact_expects_context_uninspectable_defaults_false():
+    assert _artifact_expects_context(object()) is False


### PR DESCRIPTION
## Summary

Enables running a worker with **Privy-managed custody** (auto-provision a wallet bound to its topic) and wires the builder-kit to a **local build of the allora-sdk branch** so it can be tested before the SDK is released.

Linear: [ENGN-8646](https://linear.app/alloralabs/issue/ENGN-8646/auto-provision-managed-privy-wallets-bound-to-a-topic-before-worker).

- `worker_runtime.py`: adds `--custody {local,managed}`. `managed` builds `AlloraWalletConfig.from_env()` (FORGE_API_KEY → the SDK provisions a wallet bound to the topic at startup; no local key file). Also migrates to the branch SDK's worker API — `AlloraWorker.inferer(...)` and a `RunContext`-based run fn (`raw_fn(ctx.nonce)`) — since the branch is a newer worker-API generation than the published `allora-sdk 1.0.6`.
- `pyproject.toml`: a clearly-marked **local-dev** `[tool.uv.sources]` pin of `allora-sdk` to the sibling `allora-sdk-py` worktree (which carries the unreleased auto-provision changes + generated protobuf code).

## Not for merge as-is
The `[tool.uv.sources]` pin and the worker-API migration assume the unreleased SDK. **Remove the pin and bump the `allora-sdk` version** once the SDK release with ENGN-8646 ships. This branch is for local testing in the meantime.

## Test plan
- [x] `py_compile` clean
- [x] `uv run … worker_runtime --help` imports against the local SDK and shows `--custody {local,managed}`
- [ ] Live: with a running forge-v2 backend (Privy auth key + owner configured), `FORGE_API_KEY` set, run `--custody managed --topic N` and confirm the worker provisions a managed wallet, registers, and submits (gasless when `FEE_GRANTER` = master address)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--custody managed` mode to run workers with Privy-managed wallets that auto-provision per topic (ENGN-8646), and migrates the builder kit to the branch `allora-sdk` `RunContext`-based worker API. Keeps a local-dev pin to the `allora-sdk` branch for testing until the release ships.

- **New Features**
  - `worker_runtime.py`: `--custody {local,managed}`; `managed` uses `AlloraWalletConfig.from_env()` with `FORGE_API_KEY` to provision a wallet bound to `topic_id` (no local key).
  - Migrates to `AlloraWorker.inferer(...)` and a `RunContext`-based `run` fn; raw notebook updated to match.

- **Bug Fixes**
  - Resolve wallet config in sync `main()` via `_resolve_wallet_cfg` to avoid blocking the event loop; pass pre-resolved `wallet_cfg` into `_run()`.
  - Prevent silent submission drops by detecting artifact call-shape; support both `fn(nonce)` and `fn(ctx)`.
  - CLI guards: require `FORGE_API_KEY` for managed, reject `--mnemonic-file` with managed, and warn when `FEE_GRANTER` is unset.

<sup>Written for commit 7e0e80d0440438b4088c5693decbad190996bc47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-forge-builder-kit/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

