### PR TITLE
feat: managed-custody worker lifecycle in WorkerManager (ENGN-8646)

### DIFF
--- a/allora_forge_builder_kit/worker_manager.py
+++ b/allora_forge_builder_kit/worker_manager.py
@@ -181,7 +181,14 @@ class WorkerManager:
                     "$FORGE_API_KEY and $FORGE_BACKEND_URL or pass forge_api_key/forge_backend_url"
                 )
             # Imported lazily: local-custody installs need not import the SDK signing client.
-            from allora_sdk.rpc_client.remote_signer import ForgeBackendClient
+            try:
+                from allora_sdk.rpc_client.remote_signer import ForgeBackendClient
+            except ImportError as e:
+                raise ValueError(
+                    "managed custody requires the 'allora-sdk' package "
+                    "(allora_sdk.rpc_client.remote_signer.ForgeBackendClient); install it to deploy "
+                    "managed workers"
+                ) from e
 
             self._forge_client_obj = ForgeBackendClient(self._forge_backend_url, self._forge_api_key)
             return self._forge_client_obj

--- a/allora_forge_builder_kit/worker_manager.py
+++ b/allora_forge_builder_kit/worker_manager.py
@@ -14,7 +14,7 @@ import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Optional, Any
+from typing import Any, Callable, Optional, Protocol
 
 from .worker_monitor import MONITOR_TARGETS_DDL
 
@@ -51,6 +51,31 @@ class DeployResult:
     message: str
 
 
+class ProvisionedWallet(Protocol):
+    """Structural view of a Forge-provisioned wallet (the SDK's ``SigningWalletInfo``): the
+    non-secret id + address the managed lifecycle reads back after provisioning."""
+
+    id: str
+    address: str
+
+
+class ForgeClientProtocol(Protocol):
+    """Contract for the Forge backend client used by managed custody.
+
+    Implemented by ``allora_sdk``'s ``ForgeBackendClient`` and stubbed in tests. Captures only the
+    two calls :class:`WorkerManager` makes so local-custody installs need not import the SDK and the
+    injected client is checked at the boundary instead of being typed as ``Any``.
+    """
+
+    def provision_wallet(self, topic_id: int, label: Optional[str] = None) -> ProvisionedWallet:
+        """Idempotently get-or-create the managed wallet bound to ``topic_id``."""
+        ...
+
+    def clear_association(self, wallet_id: str) -> None:
+        """Release the wallet's (user, topic) binding on the backend."""
+        ...
+
+
 class WorkerManager:
     """Lightweight local worker registry + lifecycle manager.
 
@@ -73,7 +98,7 @@ class WorkerManager:
         reconcile_on_start: bool = True,
         forge_api_key: Optional[str] = None,
         forge_backend_url: Optional[str] = None,
-        forge_client: Optional[Any] = None,
+        forge_client: Optional[ForgeClientProtocol] = None,
     ):
         """Initialise the worker manager.
 
@@ -133,7 +158,7 @@ class WorkerManager:
     # ----------------------------
     # Managed custody (Privy via Forge backend)
     # ----------------------------
-    def _forge_client(self):
+    def _forge_client(self) -> ForgeClientProtocol:
         """Return the Forge backend client for managed custody, building it lazily.
 
         Raises ``ValueError`` if the api key / backend url are missing, so a misconfigured

--- a/allora_forge_builder_kit/worker_manager.py
+++ b/allora_forge_builder_kit/worker_manager.py
@@ -14,11 +14,17 @@ import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Optional, Protocol
+from typing import Any, Callable, Literal, Optional, Protocol
 
 from .worker_monitor import MONITOR_TARGETS_DDL
 
 logger = logging.getLogger(__name__)
+
+# Wallet custody discriminant: 'local' (self-custodial key file on disk) or 'managed' (Privy
+# wallet provisioned by the Forge backend, keyed by signing_wallet_id). A Literal gives the
+# fixed two-value set type-checker coverage and IDE completion while staying a plain str on the
+# wire and in SQLite.
+CustodyMode = Literal["local", "managed"]
 
 
 @dataclass(frozen=True)
@@ -38,7 +44,7 @@ class WorkerSpec:
     reject_zero: bool = False
     # custody: "local" (self-custodial key file on disk) or "managed" (Privy-managed
     # wallet provisioned by the Forge backend; signing_wallet_id is the backend wallet id).
-    custody: str = "local"
+    custody: CustodyMode = "local"
     signing_wallet_id: Optional[str] = None
 
 
@@ -363,7 +369,7 @@ class WorkerManager:
         replace: bool = False,
         mode: str = "auto",
         reject_zero: bool = False,
-        custody: str = "local",
+        custody: CustodyMode = "local",
     ) -> DeployResult:
         artifact = Path(artifact_path)
         if not artifact.exists():

--- a/allora_forge_builder_kit/worker_manager.py
+++ b/allora_forge_builder_kit/worker_manager.py
@@ -351,8 +351,20 @@ class WorkerManager:
 
         # Managed custody: the address is not chosen locally — the backend get-or-creates a
         # Privy wallet bound to (user, topic) and returns its address (ENGN-8646 / one-worker =
-        # one-topic). `address`/`mnemonic`/`identity_alias` are local-custody inputs and ignored.
+        # one-topic). address/mnemonic/identity_alias are local-custody inputs; reject them
+        # loudly rather than silently dropping them — a silently-orphaned address or a leaked
+        # mnemonic is an operator footgun.
         if custody == "managed":
+            local_only = [
+                name
+                for name, value in (("address", address), ("mnemonic", mnemonic), ("identity_alias", identity_alias))
+                if value is not None
+            ]
+            if local_only:
+                raise ValueError(
+                    f"custody='managed' does not accept local-custody inputs {local_only}; the "
+                    "backend provisions a topic-bound wallet and assigns the address"
+                )
             return self._deploy_managed_worker(topic_id, artifact, topic_desc, replace, mode, reject_zero)
 
         # Explicit address path

--- a/allora_forge_builder_kit/worker_manager.py
+++ b/allora_forge_builder_kit/worker_manager.py
@@ -275,7 +275,7 @@ class WorkerManager:
                 """
                 SELECT topic_id, COALESCE(topic_desc, ''), address, artifact_path, identity_ref, enabled, status,
                        COALESCE(last_error, ''), deployed_at, updated_at, last_pid, last_started_at, last_stopped_at, last_exit_code,
-                       reject_zero
+                       reject_zero, COALESCE(custody, 'local'), signing_wallet_id
                 FROM workers ORDER BY topic_id, address
                 """
             ).fetchall()
@@ -296,6 +296,8 @@ class WorkerManager:
                 "last_stopped_at": row[12],
                 "last_exit_code": row[13],
                 "reject_zero": bool(row[14]) if row[14] is not None else False,
+                "custody": row[15],
+                "signing_wallet_id": row[16],
             }
             if include_desc:
                 item["topic_desc"] = row[1]

--- a/allora_forge_builder_kit/worker_manager.py
+++ b/allora_forge_builder_kit/worker_manager.py
@@ -482,6 +482,10 @@ class WorkerManager:
         client = self._forge_client()
         label = topic_desc or f"worker-topic-{topic_id}"
         info = client.provision_wallet(topic_id, label=label)
+        if not getattr(info, "address", None) or not getattr(info, "id", None):
+            raise RuntimeError(
+                f"Forge backend returned a malformed wallet for topic {topic_id}: {info!r}"
+            )
         address = info.address
 
         if self._worker_exists(topic_id, address):

--- a/allora_forge_builder_kit/worker_manager.py
+++ b/allora_forge_builder_kit/worker_manager.py
@@ -485,12 +485,27 @@ class WorkerManager:
         ]
         env: Optional[dict[str, str]] = None
         if status.get("custody") == "managed":
+            # Precheck the managed credentials before spawning so a misconfigured worker fails
+            # loudly here (start_worker/reconcile surface this) instead of the subprocess exiting
+            # right after the DB row is marked 'running'.
+            if not self._forge_api_key or not self._forge_backend_url:
+                raise ValueError(
+                    f"managed worker topic={topic_id} address={address} requires a Forge API key "
+                    "and backend URL; set $FORGE_API_KEY and $FORGE_BACKEND_URL"
+                )
+            signing_wallet_id = status.get("signing_wallet_id")
+            if not signing_wallet_id:
+                raise ValueError(
+                    f"managed worker topic={topic_id} address={address} is missing signing_wallet_id; "
+                    "re-deploy with custody='managed' to provision the backend wallet"
+                )
             cmd.extend(["--custody", "managed"])
             env = os.environ.copy()
-            if self._forge_api_key:
-                env["FORGE_API_KEY"] = self._forge_api_key
-            if self._forge_backend_url:
-                env["FORGE_BACKEND_URL"] = self._forge_backend_url
+            env["FORGE_API_KEY"] = self._forge_api_key
+            env["FORGE_BACKEND_URL"] = self._forge_backend_url
+            # Pin the exact provisioned wallet (the DB row already stores it) so the worker signs
+            # with that wallet deterministically instead of re-deriving one via topic get-or-create.
+            env["FORGE_SIGNING_WALLET_ID"] = signing_wallet_id
         else:
             key_file = self._get_key_file_for_address(address)
             if not key_file:

--- a/allora_forge_builder_kit/worker_manager.py
+++ b/allora_forge_builder_kit/worker_manager.py
@@ -457,8 +457,11 @@ class WorkerManager:
                 topic_id=topic_id,
                 address_assigned=address,
                 artifact_path=str(artifact),
-                action="replaced" if replace else "reused",
-                message=f"Updated managed worker for topic {topic_id} (wallet {address})",
+                # A managed redeploy always rotates the artifact on the one-per-topic wallet, so
+                # report 'replaced' regardless of the replace flag — labelling it 'reused' would
+                # mislead callers that branch on action to fire notifications / downstream jobs.
+                action="replaced",
+                message=f"Replaced managed worker artifact for topic {topic_id} (wallet {address})",
             )
 
         spec = WorkerSpec(

--- a/allora_forge_builder_kit/worker_manager.py
+++ b/allora_forge_builder_kit/worker_manager.py
@@ -170,18 +170,21 @@ class WorkerManager:
         Raises ``ValueError`` if the api key / backend url are missing, so a misconfigured
         managed deploy fails loudly instead of silently falling back to local custody.
         """
-        if self._forge_client_obj is not None:
-            return self._forge_client_obj
-        if not self._forge_api_key or not self._forge_backend_url:
-            raise ValueError(
-                "managed custody requires a Forge API key and backend URL; set "
-                "$FORGE_API_KEY and $FORGE_BACKEND_URL or pass forge_api_key/forge_backend_url"
-            )
-        # Imported lazily: local-custody installs need not import the SDK signing client.
-        from allora_sdk.rpc_client.remote_signer import ForgeBackendClient
+        # Build under the manager lock (reentrant RLock) so two concurrent managed deploys cannot
+        # both construct a client and leak the loser's requests.Session.
+        with self._lock:
+            if self._forge_client_obj is not None:
+                return self._forge_client_obj
+            if not self._forge_api_key or not self._forge_backend_url:
+                raise ValueError(
+                    "managed custody requires a Forge API key and backend URL; set "
+                    "$FORGE_API_KEY and $FORGE_BACKEND_URL or pass forge_api_key/forge_backend_url"
+                )
+            # Imported lazily: local-custody installs need not import the SDK signing client.
+            from allora_sdk.rpc_client.remote_signer import ForgeBackendClient
 
-        self._forge_client_obj = ForgeBackendClient(self._forge_backend_url, self._forge_api_key)
-        return self._forge_client_obj
+            self._forge_client_obj = ForgeBackendClient(self._forge_backend_url, self._forge_api_key)
+            return self._forge_client_obj
 
     # ----------------------------
     # Identity handling

--- a/allora_forge_builder_kit/worker_manager.py
+++ b/allora_forge_builder_kit/worker_manager.py
@@ -500,7 +500,10 @@ class WorkerManager:
             topic_desc,
             address,
             artifact,
-            info.id,
+            # identity_ref is a local-identity alias keying the identities table for local custody;
+            # managed workers have no identities row, so use a sentinel rather than overloading it
+            # with the Privy wallet UUID. signing_wallet_id stays the canonical wallet identifier.
+            "managed",
             reject_zero=reject_zero,
             custody="managed",
             signing_wallet_id=info.id,

--- a/allora_forge_builder_kit/worker_manager.py
+++ b/allora_forge_builder_kit/worker_manager.py
@@ -480,7 +480,9 @@ class WorkerManager:
         re-deploy refreshes the artifact against the same wallet rather than allocating a new one.
         """
         client = self._forge_client()
-        label = topic_desc or f"worker-topic-{topic_id}"
+        # Prefer a resolved topic name (same source the rest of the registry uses) over the bare
+        # topic_id fallback so the backend wallet label is human-meaningful.
+        label = self._resolve_topic_desc(topic_id, topic_desc) or f"worker-topic-{topic_id}"
         info = client.provision_wallet(topic_id, label=label)
         if not getattr(info, "address", None) or not getattr(info, "id", None):
             raise RuntimeError(

--- a/allora_forge_builder_kit/worker_manager.py
+++ b/allora_forge_builder_kit/worker_manager.py
@@ -243,7 +243,7 @@ class WorkerManager:
                 """
                 SELECT topic_id, COALESCE(topic_desc, ''), address, artifact_path, identity_ref, enabled, status,
                        COALESCE(last_error, ''), deployed_at, updated_at, last_pid, last_started_at, last_stopped_at, last_exit_code,
-                       COALESCE(custody, 'local'), signing_wallet_id
+                       COALESCE(custody, 'local'), signing_wallet_id, reject_zero
                 FROM workers WHERE topic_id=? AND address=?
                 """,
                 (topic_id, address),
@@ -267,6 +267,7 @@ class WorkerManager:
             "last_exit_code": row[13],
             "custody": row[14],
             "signing_wallet_id": row[15],
+            "reject_zero": bool(row[16]) if row[16] is not None else False,
         }
 
     def status_all(self, include_desc: bool = True) -> list[dict]:
@@ -371,8 +372,7 @@ class WorkerManager:
         if address:
             existing = self._worker_exists(topic_id, address)
             if existing and replace:
-                self._update_worker(topic_id, address, artifact, topic_desc)
-                current_artifact = Path(self.status_worker(topic_id, address)["artifact_path"])
+                current_artifact = self._update_worker(topic_id, address, artifact, topic_desc, reject_zero=reject_zero)
                 deployment_id = self._rotate_deployment(topic_id, address, current_artifact)
                 self._monitor_register(topic_id, address, deployment_id=deployment_id)
                 return DeployResult(
@@ -446,8 +446,11 @@ class WorkerManager:
         if self._worker_exists(topic_id, address):
             if not replace and mode == "strict":
                 raise ValueError(f"Managed worker already exists for topic={topic_id} address={address}")
-            self._update_worker(topic_id, address, artifact, topic_desc)
-            current_artifact = Path(self.status_worker(topic_id, address)["artifact_path"])
+            # Re-sync reject_zero and the freshly-provisioned wallet id so a redeploy cannot leave
+            # the row pointing at a stale flag or wallet binding.
+            current_artifact = self._update_worker(
+                topic_id, address, artifact, topic_desc, reject_zero=reject_zero, signing_wallet_id=info.id
+            )
             deployment_id = self._rotate_deployment(topic_id, address, current_artifact)
             self._monitor_register(topic_id, address, deployment_id=deployment_id)
             return DeployResult(
@@ -919,7 +922,22 @@ class WorkerManager:
         shutil.copy2(source_artifact, target_path)
         return target_path
 
-    def _update_worker(self, topic_id: int, address: str, artifact_path: Path, topic_desc: str | None) -> None:
+    def _update_worker(
+        self,
+        topic_id: int,
+        address: str,
+        artifact_path: Path,
+        topic_desc: str | None,
+        reject_zero: Optional[bool] = None,
+        signing_wallet_id: Optional[str] = None,
+    ) -> Path:
+        """Re-materialize the artifact, update the worker row, and return the new artifact path.
+
+        ``reject_zero`` and ``signing_wallet_id`` are written only when provided (non-None), so a
+        redeploy can re-sync flags that would otherwise drift while leaving them untouched when the
+        caller does not supply them. Returning the materialized path lets callers skip a redundant
+        status round-trip before rotating the deployment.
+        """
         resolved_desc = self._resolve_topic_desc(topic_id, topic_desc)
         managed_artifact = self._materialize_artifact(topic_id, address, artifact_path)
         with sqlite3.connect(self.db_path) as conn:
@@ -928,12 +946,22 @@ class WorkerManager:
                 UPDATE workers
                    SET artifact_path=?,
                        topic_desc=COALESCE(?, topic_desc),
+                       reject_zero=COALESCE(?, reject_zero),
+                       signing_wallet_id=COALESCE(?, signing_wallet_id),
                        updated_at=CURRENT_TIMESTAMP
                  WHERE topic_id=? AND address=?
                 """,
-                (str(managed_artifact), resolved_desc, topic_id, address),
+                (
+                    str(managed_artifact),
+                    resolved_desc,
+                    None if reject_zero is None else (1 if reject_zero else 0),
+                    signing_wallet_id,
+                    topic_id,
+                    address,
+                ),
             )
             conn.commit()
+        return managed_artifact
 
     def _validate_artifact_for_deploy(self, artifact_path: Path) -> None:
         """Block known-bad artifact variants from deployment.

--- a/allora_forge_builder_kit/worker_manager.py
+++ b/allora_forge_builder_kit/worker_manager.py
@@ -36,6 +36,10 @@ class WorkerSpec:
     identity_ref: str
     enabled: bool = True
     reject_zero: bool = False
+    # custody: "local" (self-custodial key file on disk) or "managed" (Privy-managed
+    # wallet provisioned by the Forge backend; signing_wallet_id is the backend wallet id).
+    custody: str = "local"
+    signing_wallet_id: Optional[str] = None
 
 
 @dataclass
@@ -67,6 +71,9 @@ class WorkerManager:
         network: str = "testnet",
         no_faucet: bool = False,
         reconcile_on_start: bool = True,
+        forge_api_key: Optional[str] = None,
+        forge_backend_url: Optional[str] = None,
+        forge_client: Optional[Any] = None,
     ):
         """Initialise the worker manager.
 
@@ -92,6 +99,13 @@ class WorkerManager:
                 :meth:`reconcile` during construction, which spawns
                 subprocesses for every enabled worker.  Set to *False* for
                 unit tests or when deferred startup is desired.
+            forge_api_key: Forge API key (``forge_sk_…``) used to provision /
+                release managed (Privy) wallets. Defaults to ``$FORGE_API_KEY``.
+            forge_backend_url: Forge backend base URL for managed custody.
+                Defaults to ``$FORGE_BACKEND_URL``.
+            forge_client: Pre-built Forge backend client (must expose
+                ``provision_wallet`` and ``clear_association``). Injected in tests;
+                in production it is built lazily from the api key + url.
         """
         self.db_path = Path(db_path)
         self.secrets_path = Path(secrets_path)
@@ -107,11 +121,36 @@ class WorkerManager:
         self.key_dir.mkdir(parents=True, exist_ok=True)
         self._network = network
         self._no_faucet = no_faucet
+        self._forge_api_key = forge_api_key or os.environ.get("FORGE_API_KEY")
+        self._forge_backend_url = forge_backend_url or os.environ.get("FORGE_BACKEND_URL")
+        self._forge_client_obj = forge_client
         self._lock = threading.RLock()
         self._runners: dict[tuple[int, str], dict] = {}
         self._init_db()
         if reconcile_on_start:
             self.reconcile()
+
+    # ----------------------------
+    # Managed custody (Privy via Forge backend)
+    # ----------------------------
+    def _forge_client(self):
+        """Return the Forge backend client for managed custody, building it lazily.
+
+        Raises ``ValueError`` if the api key / backend url are missing, so a misconfigured
+        managed deploy fails loudly instead of silently falling back to local custody.
+        """
+        if self._forge_client_obj is not None:
+            return self._forge_client_obj
+        if not self._forge_api_key or not self._forge_backend_url:
+            raise ValueError(
+                "managed custody requires a Forge API key and backend URL; set "
+                "$FORGE_API_KEY and $FORGE_BACKEND_URL or pass forge_api_key/forge_backend_url"
+            )
+        # Imported lazily: local-custody installs need not import the SDK signing client.
+        from allora_sdk.rpc_client.remote_signer import ForgeBackendClient
+
+        self._forge_client_obj = ForgeBackendClient(self._forge_backend_url, self._forge_api_key)
+        return self._forge_client_obj
 
     # ----------------------------
     # Identity handling
@@ -152,8 +191,8 @@ class WorkerManager:
             try:
                 conn.execute(
                     """
-                    INSERT INTO workers(topic_id, topic_desc, address, artifact_path, identity_ref, enabled, status, reject_zero, deployed_at, updated_at)
-                    VALUES(?, ?, ?, ?, ?, ?, 'stopped', ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                    INSERT INTO workers(topic_id, topic_desc, address, artifact_path, identity_ref, enabled, status, reject_zero, custody, signing_wallet_id, deployed_at, updated_at)
+                    VALUES(?, ?, ?, ?, ?, ?, 'stopped', ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
                     """,
                     (
                         spec.topic_id,
@@ -163,6 +202,8 @@ class WorkerManager:
                         spec.identity_ref,
                         1 if spec.enabled else 0,
                         1 if spec.reject_zero else 0,
+                        spec.custody,
+                        spec.signing_wallet_id,
                     ),
                 )
                 conn.commit()
@@ -175,18 +216,34 @@ class WorkerManager:
     def remove_worker(self, topic_id: int, address: str, force: bool = False) -> None:
         if force:
             self.stop_worker(topic_id, address)
+        custody, signing_wallet_id = self._get_custody(topic_id, address)
         self._archive_active_deployment(topic_id, address)
         with sqlite3.connect(self.db_path) as conn:
             conn.execute("DELETE FROM workers WHERE topic_id=? AND address=?", (topic_id, address))
             conn.commit()
         self._monitor_disable(topic_id, address)
+        # Managed custody: release the (user, topic) binding on the backend so the topic slot is
+        # freed. Best-effort — the worker is already gone locally, and the backend get-or-create is
+        # idempotent, so a stale binding is simply reused on the next deploy rather than leaking.
+        if custody == "managed" and signing_wallet_id:
+            try:
+                self._forge_client().clear_association(signing_wallet_id)
+                logger.info("released managed wallet %s topic binding (topic %s)", signing_wallet_id, topic_id)
+            except Exception as e:  # noqa: BLE001 - decommission cleanup must never raise
+                logger.warning(
+                    "clear-association failed for managed wallet %s (topic %s): %s; removed locally anyway",
+                    signing_wallet_id,
+                    topic_id,
+                    e,
+                )
 
     def status_worker(self, topic_id: int, address: str) -> dict:
         with sqlite3.connect(self.db_path) as conn:
             row = conn.execute(
                 """
                 SELECT topic_id, COALESCE(topic_desc, ''), address, artifact_path, identity_ref, enabled, status,
-                       COALESCE(last_error, ''), deployed_at, updated_at, last_pid, last_started_at, last_stopped_at, last_exit_code
+                       COALESCE(last_error, ''), deployed_at, updated_at, last_pid, last_started_at, last_stopped_at, last_exit_code,
+                       COALESCE(custody, 'local'), signing_wallet_id
                 FROM workers WHERE topic_id=? AND address=?
                 """,
                 (topic_id, address),
@@ -208,6 +265,8 @@ class WorkerManager:
             "last_started_at": row[11],
             "last_stopped_at": row[12],
             "last_exit_code": row[13],
+            "custody": row[14],
+            "signing_wallet_id": row[15],
         }
 
     def status_all(self, include_desc: bool = True) -> list[dict]:
@@ -276,6 +335,7 @@ class WorkerManager:
         replace: bool = False,
         mode: str = "auto",
         reject_zero: bool = False,
+        custody: str = "local",
     ) -> DeployResult:
         artifact = Path(artifact_path)
         if not artifact.exists():
@@ -284,6 +344,14 @@ class WorkerManager:
 
         if mode not in {"auto", "strict"}:
             raise ValueError("mode must be 'auto' or 'strict'")
+        if custody not in {"local", "managed"}:
+            raise ValueError("custody must be 'local' or 'managed'")
+
+        # Managed custody: the address is not chosen locally — the backend get-or-creates a
+        # Privy wallet bound to (user, topic) and returns its address (ENGN-8646 / one-worker =
+        # one-topic). `address`/`mnemonic`/`identity_alias` are local-custody inputs and ignored.
+        if custody == "managed":
+            return self._deploy_managed_worker(topic_id, artifact, topic_desc, replace, mode, reject_zero)
 
         # Explicit address path
         if address:
@@ -343,18 +411,69 @@ class WorkerManager:
             message=f"Deployed worker for topic {topic_id} with address {ident.address}",
         )
 
+    def _deploy_managed_worker(
+        self,
+        topic_id: int,
+        artifact: Path,
+        topic_desc: str | None,
+        replace: bool,
+        mode: str,
+        reject_zero: bool,
+    ) -> DeployResult:
+        """Provision (idempotent get-or-create) a managed Privy wallet bound to ``topic_id`` and
+        register a managed worker against its backend-assigned address. One wallet per topic, so a
+        re-deploy refreshes the artifact against the same wallet rather than allocating a new one.
+        """
+        client = self._forge_client()
+        label = topic_desc or f"worker-topic-{topic_id}"
+        info = client.provision_wallet(topic_id, label=label)
+        address = info.address
+
+        if self._worker_exists(topic_id, address):
+            if not replace and mode == "strict":
+                raise ValueError(f"Managed worker already exists for topic={topic_id} address={address}")
+            self._update_worker(topic_id, address, artifact, topic_desc)
+            current_artifact = Path(self.status_worker(topic_id, address)["artifact_path"])
+            deployment_id = self._rotate_deployment(topic_id, address, current_artifact)
+            self._monitor_register(topic_id, address, deployment_id=deployment_id)
+            return DeployResult(
+                topic_id=topic_id,
+                address_assigned=address,
+                artifact_path=str(artifact),
+                action="replaced" if replace else "reused",
+                message=f"Updated managed worker for topic {topic_id} (wallet {address})",
+            )
+
+        spec = WorkerSpec(
+            topic_id,
+            topic_desc,
+            address,
+            artifact,
+            info.id,
+            reject_zero=reject_zero,
+            custody="managed",
+            signing_wallet_id=info.id,
+        )
+        self.add_worker(spec)
+        return DeployResult(
+            topic_id=topic_id,
+            address_assigned=address,
+            artifact_path=str(artifact),
+            action="created",
+            message=f"Provisioned managed wallet {address} for topic {topic_id}",
+        )
+
     # ----------------------------
     # Lifecycle (persistent managed process runner)
     # ----------------------------
-    def start_worker(self, topic_id: int, address: str) -> None:
-        status = self.status_worker(topic_id, address)
-        pid = status.get("last_pid")
-        if pid and self._is_pid_alive(pid):
-            self._set_worker_status(topic_id, address, status="running", last_error=None)
-            return
+    def _build_run_command(self, topic_id: int, address: str, status: dict) -> tuple[list[str], Optional[dict[str, str]]]:
+        """Build the ``worker_runtime`` argv (and subprocess env) for a worker slot.
 
-        log_path = self.runtime_log_dir / f"worker_{topic_id}_{address}.log"
-        log_f = open(log_path, "ab")
+        Local custody passes the on-disk key file via ``--mnemonic-file``. Managed custody passes
+        ``--custody managed`` and injects the Forge credentials into the env so the SDK provisions
+        and signs against the backend with no local key. Returns ``(argv, env)``; ``env`` is None
+        for local custody (inherit the parent environment unchanged).
+        """
         cmd = [
             sys.executable,
             "-m",
@@ -364,22 +483,44 @@ class WorkerManager:
             "--artifact",
             str(status["artifact_path"]),
         ]
-
-        key_file = self._get_key_file_for_address(address)
-        if not key_file:
-            log_f.close()
-            raise FileNotFoundError(
-                f"No key file found for address {address}. "
-                f"Check worker_secrets.json and worker_keys/ directory."
-            )
-        cmd.extend(["--mnemonic-file", str(key_file)])
+        env: Optional[dict[str, str]] = None
+        if status.get("custody") == "managed":
+            cmd.extend(["--custody", "managed"])
+            env = os.environ.copy()
+            if self._forge_api_key:
+                env["FORGE_API_KEY"] = self._forge_api_key
+            if self._forge_backend_url:
+                env["FORGE_BACKEND_URL"] = self._forge_backend_url
+        else:
+            key_file = self._get_key_file_for_address(address)
+            if not key_file:
+                raise FileNotFoundError(
+                    f"No key file found for address {address}. "
+                    f"Check worker_secrets.json and worker_keys/ directory."
+                )
+            cmd.extend(["--mnemonic-file", str(key_file)])
         cmd.extend(["--network", self._network])
-
         if self._no_faucet:
             cmd.append("--no-faucet")
         if status.get("reject_zero"):
             cmd.append("--reject-zero")
-        proc = subprocess.Popen(cmd, stdout=log_f, stderr=subprocess.STDOUT, cwd=str(Path.cwd()))
+        return cmd, env
+
+    def start_worker(self, topic_id: int, address: str) -> None:
+        status = self.status_worker(topic_id, address)
+        pid = status.get("last_pid")
+        if pid and self._is_pid_alive(pid):
+            self._set_worker_status(topic_id, address, status="running", last_error=None)
+            return
+
+        log_path = self.runtime_log_dir / f"worker_{topic_id}_{address}.log"
+        log_f = open(log_path, "ab")
+        try:
+            cmd, env = self._build_run_command(topic_id, address, status)
+        except Exception:
+            log_f.close()
+            raise
+        proc = subprocess.Popen(cmd, stdout=log_f, stderr=subprocess.STDOUT, cwd=str(Path.cwd()), env=env)
         key = (topic_id, address)
         self._runners[key] = {"proc": proc, "log": log_f}
 
@@ -563,6 +704,8 @@ class WorkerManager:
                     last_stopped_at TEXT,
                     last_exit_code INTEGER,
                     reject_zero INTEGER NOT NULL DEFAULT 0,
+                    custody TEXT NOT NULL DEFAULT 'local',
+                    signing_wallet_id TEXT,
                     UNIQUE(topic_id, address)
                 )
                 """
@@ -596,6 +739,10 @@ class WorkerManager:
                 conn.execute("ALTER TABLE workers ADD COLUMN last_exit_code INTEGER")
             if "reject_zero" not in cols:
                 conn.execute("ALTER TABLE workers ADD COLUMN reject_zero INTEGER NOT NULL DEFAULT 0")
+            if "custody" not in cols:
+                conn.execute("ALTER TABLE workers ADD COLUMN custody TEXT NOT NULL DEFAULT 'local'")
+            if "signing_wallet_id" not in cols:
+                conn.execute("ALTER TABLE workers ADD COLUMN signing_wallet_id TEXT")
             conn.commit()
         if not self.secrets_path.exists():
             self.secrets_path.write_text("{}")
@@ -712,6 +859,17 @@ class WorkerManager:
         with sqlite3.connect(self.db_path) as conn:
             row = conn.execute("SELECT 1 FROM workers WHERE topic_id=? AND address=?", (topic_id, address)).fetchone()
         return row is not None
+
+    def _get_custody(self, topic_id: int, address: str) -> tuple[str, Optional[str]]:
+        """Return ``(custody, signing_wallet_id)`` for a worker; ``("local", None)`` if absent."""
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                "SELECT custody, signing_wallet_id FROM workers WHERE topic_id=? AND address=?",
+                (topic_id, address),
+            ).fetchone()
+        if not row:
+            return ("local", None)
+        return (row[0] or "local", row[1])
 
     def _address_has_other_topics(self, address: str) -> bool:
         with sqlite3.connect(self.db_path) as conn:

--- a/tests/test_worker_manager.py
+++ b/tests/test_worker_manager.py
@@ -427,3 +427,20 @@ def test_managed_env_from_build_run_command_constructs_wallet_config(tmp_path: P
 
     cfg = AlloraWalletConfig.from_env()
     assert cfg.wallet is fake_wallet
+
+
+def test_status_all_includes_custody_and_signing_wallet_id(tmp_path: Path):
+    """status_all() exposes the same custody/signing_wallet_id contract as status_worker(), so
+    a dashboard iterating status_all() can tell managed from local without an N+1 round-trip."""
+    client = _FakeForgeClient()
+    manager = _managed_manager(tmp_path, client)
+    artifact = tmp_path / "m.pkl"
+    artifact.write_text("m")
+    manager.deploy_worker(topic_id=42, artifact_path=artifact, custody="managed")
+
+    row = [w for w in manager.status_all() if w["topic_id"] == 42][0]
+    assert row["custody"] == "managed"
+    assert row["signing_wallet_id"] == "wallet-42"
+
+    worker = manager.status_worker(topic_id=42, address="allo1managed0042")
+    assert {"custody", "signing_wallet_id"} <= (set(row) & set(worker))

--- a/tests/test_worker_manager.py
+++ b/tests/test_worker_manager.py
@@ -4,7 +4,7 @@ import sqlite3
 
 import pytest
 
-from allora_forge_builder_kit.worker_manager import WorkerManager, WorkerSpec
+from allora_forge_builder_kit.worker_manager import ForgeClientProtocol, WorkerManager, WorkerSpec
 
 
 class _FakeForgeClient:
@@ -28,7 +28,7 @@ class _FakeForgeClient:
         self.cleared.append(wallet_id)
 
 
-def _managed_manager(tmp_path: Path, client, **kwargs) -> WorkerManager:
+def _managed_manager(tmp_path: Path, client: ForgeClientProtocol, **kwargs) -> WorkerManager:
     return WorkerManager(
         db_path=tmp_path / "state.db",
         secrets_path=tmp_path / "secrets.json",

--- a/tests/test_worker_manager.py
+++ b/tests/test_worker_manager.py
@@ -1,9 +1,42 @@
 from pathlib import Path
+from types import SimpleNamespace
 import sqlite3
 
 import pytest
 
 from allora_forge_builder_kit.worker_manager import WorkerManager, WorkerSpec
+
+
+class _FakeForgeClient:
+    """Stand-in for allora_sdk's ForgeBackendClient. Idempotent get-or-create by topic:
+    the same topic always yields the same address/id, mirroring the backend's one-wallet-
+    per-(user, topic) contract."""
+
+    def __init__(self):
+        self.provisioned: list[tuple[int, str | None]] = []
+        self.cleared: list[str] = []
+
+    def provision_wallet(self, topic_id: int, label: str | None = None):
+        self.provisioned.append((topic_id, label))
+        return SimpleNamespace(
+            id=f"wallet-{topic_id}",
+            address=f"allo1managed{topic_id:04d}",
+            pubkey="ab" * 33,
+        )
+
+    def clear_association(self, wallet_id: str) -> None:
+        self.cleared.append(wallet_id)
+
+
+def _managed_manager(tmp_path: Path, client, **kwargs) -> WorkerManager:
+    return WorkerManager(
+        db_path=tmp_path / "state.db",
+        secrets_path=tmp_path / "secrets.json",
+        identity_creator=lambda: ("unused", "unused", "unused"),
+        forge_client=client,
+        reconcile_on_start=False,
+        **kwargs,
+    )
 
 
 def _new_manager(tmp_path: Path) -> WorkerManager:
@@ -193,3 +226,125 @@ def test_status_all_with_logs_returns_tail_and_artifact_path(tmp_path: Path):
 
     assert row["artifact_path"].endswith(".pkl")
     assert row["log_tail"] == ["l3", "l4"]
+
+
+# ----------------------------
+# Managed custody (ENGN-8646)
+# ----------------------------
+def test_deploy_managed_provisions_and_registers(tmp_path: Path):
+    client = _FakeForgeClient()
+    manager = _managed_manager(tmp_path, client)
+    artifact = tmp_path / "m.pkl"
+    artifact.write_text("m")
+
+    result = manager.deploy_worker(topic_id=42, artifact_path=artifact, custody="managed")
+
+    assert result.action == "created"
+    assert result.address_assigned == "allo1managed0042"
+    # Provisioned exactly once, get-or-create by topic with a display label.
+    assert client.provisioned == [(42, "worker-topic-42")]
+
+    status = manager.status_worker(topic_id=42, address="allo1managed0042")
+    assert status["custody"] == "managed"
+    assert status["signing_wallet_id"] == "wallet-42"
+    assert status["artifact_path"].endswith(".pkl")
+
+
+def test_deploy_managed_redeploy_reuses_same_wallet(tmp_path: Path):
+    client = _FakeForgeClient()
+    manager = _managed_manager(tmp_path, client)
+    v1 = tmp_path / "v1.pkl"
+    v2 = tmp_path / "v2.pkl"
+    v1.write_text("v1")
+    v2.write_text("v2")
+
+    manager.deploy_worker(topic_id=8, artifact_path=v1, custody="managed")
+    result = manager.deploy_worker(topic_id=8, artifact_path=v2, custody="managed", replace=True)
+
+    assert result.action == "replaced"
+    assert result.address_assigned == "allo1managed0008"
+    # One worker per topic — no second worker row was created.
+    assert len([w for w in manager.status_all() if w["topic_id"] == 8]) == 1
+
+
+def test_build_run_command_managed_injects_forge_env_and_no_keyfile(tmp_path: Path):
+    client = _FakeForgeClient()
+    manager = _managed_manager(
+        tmp_path,
+        client,
+        forge_api_key="forge_sk_test",
+        forge_backend_url="http://localhost:8080",
+    )
+    artifact = tmp_path / "m.pkl"
+    artifact.write_text("m")
+    manager.deploy_worker(topic_id=7, artifact_path=artifact, custody="managed")
+
+    status = manager.status_worker(topic_id=7, address="allo1managed0007")
+    cmd, env = manager._build_run_command(7, "allo1managed0007", status)
+
+    assert "--custody" in cmd
+    assert cmd[cmd.index("--custody") + 1] == "managed"
+    assert "--mnemonic-file" not in cmd
+    assert env is not None
+    assert env["FORGE_API_KEY"] == "forge_sk_test"
+    assert env["FORGE_BACKEND_URL"] == "http://localhost:8080"
+
+
+def test_remove_managed_worker_clears_association(tmp_path: Path):
+    client = _FakeForgeClient()
+    manager = _managed_manager(tmp_path, client)
+    artifact = tmp_path / "m.pkl"
+    artifact.write_text("m")
+    manager.deploy_worker(topic_id=9, artifact_path=artifact, custody="managed")
+
+    manager.remove_worker(topic_id=9, address="allo1managed0009")
+
+    assert client.cleared == ["wallet-9"]
+    with pytest.raises(KeyError):
+        manager.status_worker(topic_id=9, address="allo1managed0009")
+
+
+def test_remove_managed_worker_tolerates_clear_failure(tmp_path: Path):
+    class _FailingClient(_FakeForgeClient):
+        def clear_association(self, wallet_id: str) -> None:
+            raise RuntimeError("backend down")
+
+    client = _FailingClient()
+    manager = _managed_manager(tmp_path, client)
+    artifact = tmp_path / "m.pkl"
+    artifact.write_text("m")
+    manager.deploy_worker(topic_id=5, artifact_path=artifact, custody="managed")
+
+    # Decommission cleanup must never raise — the worker is still removed locally.
+    manager.remove_worker(topic_id=5, address="allo1managed0005")
+    with pytest.raises(KeyError):
+        manager.status_worker(topic_id=5, address="allo1managed0005")
+
+
+def test_remove_local_worker_does_not_clear(tmp_path: Path):
+    client = _FakeForgeClient()
+    manager = _managed_manager(tmp_path, client)
+    ident = manager.ensure_identity(alias="alpha")
+    artifact = tmp_path / "l.pkl"
+    artifact.write_text("l")
+    manager.deploy_worker(topic_id=3, artifact_path=artifact, address=ident.address)
+
+    manager.remove_worker(topic_id=3, address=ident.address)
+
+    assert client.cleared == []
+
+
+def test_deploy_managed_requires_forge_credentials(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("FORGE_API_KEY", raising=False)
+    monkeypatch.delenv("FORGE_BACKEND_URL", raising=False)
+    manager = WorkerManager(
+        db_path=tmp_path / "state.db",
+        secrets_path=tmp_path / "secrets.json",
+        identity_creator=lambda: ("unused", "unused", "unused"),
+        reconcile_on_start=False,
+    )
+    artifact = tmp_path / "m.pkl"
+    artifact.write_text("m")
+
+    with pytest.raises(ValueError, match="managed custody requires"):
+        manager.deploy_worker(topic_id=1, artifact_path=artifact, custody="managed")

--- a/tests/test_worker_manager.py
+++ b/tests/test_worker_manager.py
@@ -291,6 +291,20 @@ def test_managed_redeploy_syncs_reject_zero_into_db_and_command(tmp_path: Path):
     assert "--reject-zero" in cmd
 
 
+def test_managed_auto_redeploy_reports_replaced_not_reused(tmp_path: Path):
+    client = _FakeForgeClient()
+    manager = _managed_manager(tmp_path, client)
+    v1 = tmp_path / "v1.pkl"
+    v2 = tmp_path / "v2.pkl"
+    v1.write_text("v1")
+    v2.write_text("v2")
+
+    manager.deploy_worker(topic_id=8, artifact_path=v1, custody="managed")
+    # Auto mode (no replace=True) still rotates the artifact on the one-per-topic wallet.
+    result = manager.deploy_worker(topic_id=8, artifact_path=v2, custody="managed")
+    assert result.action == "replaced"
+
+
 def test_build_run_command_managed_injects_forge_env_and_no_keyfile(tmp_path: Path):
     client = _FakeForgeClient()
     manager = _managed_manager(

--- a/tests/test_worker_manager.py
+++ b/tests/test_worker_manager.py
@@ -267,6 +267,30 @@ def test_deploy_managed_redeploy_reuses_same_wallet(tmp_path: Path):
     assert len([w for w in manager.status_all() if w["topic_id"] == 8]) == 1
 
 
+def test_managed_redeploy_syncs_reject_zero_into_db_and_command(tmp_path: Path):
+    client = _FakeForgeClient()
+    manager = _managed_manager(
+        tmp_path,
+        client,
+        forge_api_key="forge_sk_test",
+        forge_backend_url="http://localhost:8080",
+    )
+    v1 = tmp_path / "v1.pkl"
+    v2 = tmp_path / "v2.pkl"
+    v1.write_text("v1")
+    v2.write_text("v2")
+
+    manager.deploy_worker(topic_id=8, artifact_path=v1, custody="managed", reject_zero=False)
+    manager.deploy_worker(topic_id=8, artifact_path=v2, custody="managed", replace=True, reject_zero=True)
+
+    row = [w for w in manager.status_all() if w["topic_id"] == 8][0]
+    assert row["reject_zero"] is True
+
+    status = manager.status_worker(topic_id=8, address="allo1managed0008")
+    cmd, _ = manager._build_run_command(8, "allo1managed0008", status)
+    assert "--reject-zero" in cmd
+
+
 def test_build_run_command_managed_injects_forge_env_and_no_keyfile(tmp_path: Path):
     client = _FakeForgeClient()
     manager = _managed_manager(

--- a/tests/test_worker_manager.py
+++ b/tests/test_worker_manager.py
@@ -397,6 +397,20 @@ def test_remove_local_worker_does_not_clear(tmp_path: Path):
     assert client.cleared == []
 
 
+def test_deploy_managed_rejects_malformed_backend_wallet(tmp_path: Path):
+    class _BadClient(_FakeForgeClient):
+        def provision_wallet(self, topic_id: int, label: str | None = None):
+            return SimpleNamespace(id="", address="", pubkey="")
+
+    client = _BadClient()
+    manager = _managed_manager(tmp_path, client)
+    artifact = tmp_path / "m.pkl"
+    artifact.write_text("m")
+
+    with pytest.raises(RuntimeError, match="malformed wallet"):
+        manager.deploy_worker(topic_id=1, artifact_path=artifact, custody="managed")
+
+
 def test_deploy_managed_rejects_local_only_inputs(tmp_path: Path):
     client = _FakeForgeClient()
     manager = _managed_manager(tmp_path, client)

--- a/tests/test_worker_manager.py
+++ b/tests/test_worker_manager.py
@@ -288,6 +288,28 @@ def test_build_run_command_managed_injects_forge_env_and_no_keyfile(tmp_path: Pa
     assert env is not None
     assert env["FORGE_API_KEY"] == "forge_sk_test"
     assert env["FORGE_BACKEND_URL"] == "http://localhost:8080"
+    # The DB-stored signing wallet id is pinned into the env so the worker signs with the exact
+    # provisioned wallet (deterministic) rather than re-deriving via topic get-or-create.
+    assert env["FORGE_SIGNING_WALLET_ID"] == "wallet-7"
+
+
+def test_build_run_command_managed_without_signing_wallet_id_raises(tmp_path: Path):
+    client = _FakeForgeClient()
+    manager = _managed_manager(
+        tmp_path,
+        client,
+        forge_api_key="forge_sk_test",
+        forge_backend_url="http://localhost:8080",
+    )
+    artifact = tmp_path / "m.pkl"
+    artifact.write_text("m")
+    manager.deploy_worker(topic_id=7, artifact_path=artifact, custody="managed")
+    status = manager.status_worker(topic_id=7, address="allo1managed0007")
+    status["signing_wallet_id"] = None
+
+    # Fails loudly before spawning rather than letting the subprocess exit post-'running'.
+    with pytest.raises(ValueError, match="signing_wallet_id"):
+        manager._build_run_command(7, "allo1managed0007", status)
 
 
 def test_remove_managed_worker_clears_association(tmp_path: Path):

--- a/tests/test_worker_manager.py
+++ b/tests/test_worker_manager.py
@@ -370,3 +370,60 @@ def test_deploy_managed_requires_forge_credentials(tmp_path: Path, monkeypatch):
 
     with pytest.raises(ValueError, match="managed custody requires"):
         manager.deploy_worker(topic_id=1, artifact_path=artifact, custody="managed")
+
+
+# ----------------------------
+# Real-SDK contract tests (synth-001 / synth-003): exercise the actual allora_sdk surface
+# the managed lifecycle depends on, so a cross-repo contract break cannot hide behind the
+# _FakeForgeClient stub or an argv-only assertion.
+# ----------------------------
+def test_real_forge_backend_client_exposes_managed_custody_methods():
+    """The real ForgeBackendClient WorkerManager imports must expose the two methods the
+    lifecycle calls: provision_wallet (deploy) and clear_association (remove)."""
+    from allora_sdk.rpc_client.remote_signer import ForgeBackendClient
+
+    assert hasattr(ForgeBackendClient, "provision_wallet")
+    assert hasattr(ForgeBackendClient, "clear_association")
+
+
+def test_real_sdk_wallet_config_defers_for_managed_worker_without_crashing(monkeypatch):
+    """Refutes 'every managed worker crashes with No wallet credentials provided': with only
+    FORGE_API_KEY set (the deferred managed contract), the real AlloraWalletConfig.from_env()
+    returns a managed config instead of raising."""
+    from allora_sdk.rpc_client.config import AlloraWalletConfig
+
+    monkeypatch.setenv("FORGE_API_KEY", "forge_sk_test")
+    monkeypatch.setenv("FORGE_BACKEND_URL", "http://localhost:8080")
+    for key in ("FORGE_SIGNING_WALLET_ID", "PRIVATE_KEY", "MNEMONIC", "MNEMONIC_FILE"):
+        monkeypatch.delenv(key, raising=False)
+
+    cfg = AlloraWalletConfig.from_env()
+    assert cfg.forge_api_key == "forge_sk_test"
+
+
+def test_managed_env_from_build_run_command_constructs_wallet_config(tmp_path: Path, monkeypatch):
+    """The exact env _build_run_command injects for a managed worker drives the real
+    AlloraWalletConfig.from_env() to a wallet-backed config without raising (HTTP mocked)."""
+    import allora_sdk.rpc_client.remote_signer as rs
+    from allora_sdk.rpc_client.config import AlloraWalletConfig
+
+    client = _FakeForgeClient()
+    manager = _managed_manager(
+        tmp_path,
+        client,
+        forge_api_key="forge_sk_test",
+        forge_backend_url="http://localhost:8080",
+    )
+    artifact = tmp_path / "m.pkl"
+    artifact.write_text("m")
+    manager.deploy_worker(topic_id=7, artifact_path=artifact, custody="managed")
+    status = manager.status_worker(topic_id=7, address="allo1managed0007")
+    _, env = manager._build_run_command(7, "allo1managed0007", status)
+
+    fake_wallet = SimpleNamespace(address=lambda: "allo1managed0007")
+    monkeypatch.setattr(rs, "make_remote_wallet", lambda *a, **k: fake_wallet)
+    for key in ("FORGE_API_KEY", "FORGE_BACKEND_URL", "FORGE_SIGNING_WALLET_ID"):
+        monkeypatch.setenv(key, env[key])
+
+    cfg = AlloraWalletConfig.from_env()
+    assert cfg.wallet is fake_wallet

--- a/tests/test_worker_manager.py
+++ b/tests/test_worker_manager.py
@@ -248,6 +248,9 @@ def test_deploy_managed_provisions_and_registers(tmp_path: Path):
     assert status["custody"] == "managed"
     assert status["signing_wallet_id"] == "wallet-42"
     assert status["artifact_path"].endswith(".pkl")
+    # identity_ref is a sentinel for managed workers (no identities row); the canonical wallet id
+    # lives in signing_wallet_id, not overloaded into identity_ref.
+    assert status["identity_ref"] == "managed"
 
 
 def test_deploy_managed_redeploy_reuses_same_wallet(tmp_path: Path):

--- a/tests/test_worker_manager.py
+++ b/tests/test_worker_manager.py
@@ -356,6 +356,17 @@ def test_remove_local_worker_does_not_clear(tmp_path: Path):
     assert client.cleared == []
 
 
+def test_deploy_managed_rejects_local_only_inputs(tmp_path: Path):
+    client = _FakeForgeClient()
+    manager = _managed_manager(tmp_path, client)
+    artifact = tmp_path / "m.pkl"
+    artifact.write_text("m")
+
+    for kwargs in ({"address": "allo1xxx"}, {"mnemonic": "abandon abandon"}, {"identity_alias": "alias"}):
+        with pytest.raises(ValueError, match="local-custody inputs"):
+            manager.deploy_worker(topic_id=1, artifact_path=artifact, custody="managed", **kwargs)
+
+
 def test_deploy_managed_requires_forge_credentials(tmp_path: Path, monkeypatch):
     monkeypatch.delenv("FORGE_API_KEY", raising=False)
     monkeypatch.delenv("FORGE_BACKEND_URL", raising=False)


### PR DESCRIPTION
## Summary

Builds the **orchestrator-level managed-custody flow** so the dev kit can run Privy-managed workers end-to-end — the deferred Phase-3 piece of [ENGN-8646](https://linear.app/alloralabs/issue/ENGN-8646/auto-provision-managed-privy-wallets-bound-to-a-topic-before-worker). Previously `WorkerManager` was local-custody only (generated a mnemonic, persisted a key file, keyed everything by a local address); the `--custody managed` switch only existed at the single-worker `worker_runtime` layer.

Stacked on **#34** (the `--custody managed` switch + local SDK pin) and depends on **allora-sdk-py #81** (`provision_wallet` + the new `clear_association`).

- `deploy_worker(custody="managed")` provisions an idempotent get-or-create managed wallet bound to the topic via the Forge backend and registers the worker against the **backend-assigned address** — no local key. One wallet per topic (ENGN-8572); a re-deploy refreshes the artifact on the same wallet rather than allocating a new one.
- `start_worker` launches managed workers with `--custody managed` and injects `FORGE_API_KEY`/`FORGE_BACKEND_URL` into the subprocess env (no `--mnemonic-file`). Extracted into a testable `_build_run_command(...)`.
- `remove_worker` releases the `(user, topic)` binding via `clear-association` on decommission — **best-effort**: the worker is removed locally regardless, and the backend get-or-create is idempotent so a stale binding is simply reused next deploy.
- `workers` table gains `custody` + `signing_wallet_id` (with the existing lightweight `ALTER TABLE` migration pattern); `status_worker` surfaces them. The Forge client is built lazily from `FORGE_*` env and is injectable for tests.

The managed flow reuses `allora_sdk`'s `ForgeBackendClient` rather than re-implementing the (security-hardened) HTTP plumbing.

## Local testing
Inherits #34's `[tool.uv.sources]` local SDK pin, so it runs against the local branch build now. Live run needs a forge-v2 backend (Privy auth key + owner) and `FORGE_API_KEY`/`FORGE_BACKEND_URL`.

## Test plan
- [x] `tests/test_worker_manager.py` — 15 pass (8 existing + 7 new): provision/register, idempotent redeploy, managed command/env construction, clear-on-remove, clear-failure tolerance, local-not-cleared, missing-credentials error
- [x] `allora-sdk-py` — 17 pass (added `test_clear_association`)
- [x] Imports verified against the local SDK build
- [ ] Live: deploy + start + remove a managed worker against a running backend and confirm provision → register → submit, and that remove clears the association

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add managed custody to WorkerManager so the orchestrator can run Privy-managed workers end-to-end without local keys. Implements ENGN-8646 by provisioning one backend-managed wallet per (user, topic) and reusing it on redeploy.

- **New Features**
  - `deploy_worker(custody="managed")` provisions an idempotent wallet via the Forge backend and registers the worker with the backend-assigned address; one wallet per topic; redeploy updates the artifact on the same wallet and syncs `reject_zero`/`signing_wallet_id`. Rejects local-only inputs (`address`/`mnemonic`/`identity_alias`) when `custody="managed"`.
  - `start_worker` adds `--custody managed`, injects `FORGE_API_KEY`/`FORGE_BACKEND_URL`/`FORGE_SIGNING_WALLET_ID`, and prechecks credentials and wallet id; command building extracted to `_build_run_command(...)`.
  - `remove_worker` calls backend clear-association to release the (user, topic) binding; best-effort (local removal always proceeds).
  - `workers` table adds `custody` and `signing_wallet_id`; `status_worker` and `status_all` return them.
  - Safety and robustness: validate backend wallet fields, friendly error if `allora-sdk` is missing, build the Forge client under the manager lock, type the client via a Protocol, use `identity_ref="managed"` for managed rows, and report `action="replaced"` on managed redeploys.

- **Migration**
  - Set `FORGE_API_KEY` and `FORGE_BACKEND_URL` to use managed custody; otherwise `deploy_worker(..., custody="managed")` fails fast.
  - No manual DB migration needed; columns are added on startup.

<sup>Written for commit 9aa52267fd4c9ad311769f52c7919a374f0269c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/allora-forge-builder-kit/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

